### PR TITLE
Sync with template-wordpress v0.3.0

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,19 @@
+have_fun: true
+
+ignore_patterns:
+  - "vendor/**"
+  - "node_modules/**"
+  - "*.min.js"
+  - "*.min.css"
+  - "package-lock.json"
+  - "composer.lock"
+
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: true

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,55 @@
+# Classic to Gutenberg - Code Review Style Guide
+
+## Project Context
+
+WordPress plugin for batch migration of classic editor content to Gutenberg blocks. PHP 8.2+ minimum, WordPress 6.2+, strict types everywhere.
+
+## Code Style
+
+- Flag inline comments that merely restate what the code does instead of explaining intent or reasoning.
+- Flag commented-out code.
+- Do not flag docblocks — these may be required by coding standards even when the function is self-explanatory.
+- Flag new code that duplicates existing functionality in the repository.
+
+## PHP
+
+- Follow the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/).
+- Use tabs for indentation (not spaces).
+- All files must declare `declare(strict_types=1)`.
+- PSR-4 autoloading under `src/` with the `Apermo\ClassicToGutenberg` namespace.
+- All user-facing strings must be translatable using `__()`, `_e()`, `esc_html__()`, `esc_html_e()`, `esc_attr__()`, or `esc_attr_e()` with the `classic-to-gutenberg` text domain.
+- Translator comments (`/* translators: ... */`) are required before any translation function call that contains placeholders.
+- All output must be properly escaped using `esc_html()`, `esc_attr()`, `esc_url()`, `wp_kses_post()`, etc.
+- Global functions and constants must be fully qualified in namespaced code.
+- Coding standards are enforced via PHPCS with the custom `Apermo` ruleset.
+- Static analysis via PHPStan at level 6.
+
+## File Operations
+
+- Flag files that appear to be deleted and re-added as new files instead of being moved/renamed (losing git history).
+
+## Build & Packaging
+
+- Flag newly added files or directories that are missing from build/packaging configs (`.gitattributes`, CI workflows, etc.).
+
+## Security
+
+- All user input must be sanitized and validated.
+- All output must be escaped.
+- Nonce verification is required for form submissions.
+
+## Testing
+
+- Unit tests use PHPUnit with Brain Monkey for mocking WordPress functions.
+- Integration tests run against a real WordPress instance.
+- E2E tests use Playwright.
+- If tests exist for a changed area, flag missing or insufficient test coverage for new/modified code.
+
+## Documentation
+
+- If a change affects user-facing behavior, flag missing updates to README, CHANGELOG, or inline docblocks.
+
+## Commits
+
+- This project uses Conventional Commits with a 50-char subject / 72-char body limit.
+- Each commit should address a single concern.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,33 @@
+name: Bug Report
+description: Report a bug
+labels: ["type: bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: input
+    id: wp-version
+    attributes:
+      label: WordPress version
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP version

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature Request
+description: Suggest a new feature
+labels: ["type: feature"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like to see?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this needed?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds or alternative approaches?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do? -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring
+- [ ] Documentation
+
+## Checklist
+
+- [ ] PHPCS passes (`composer cs`)
+- [ ] PHPStan passes (`composer analyse`)
+- [ ] Tests pass (`composer test`)
+- [ ] CHANGELOG.md updated
+
+## Test plan
+
+<!-- How was this tested? -->

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=8.2"
     },
     "require-dev": {
-        "apermo/apermo-coding-standards": "^2.0",
+        "apermo/apermo-coding-standards": "^2.6",
         "apermo/phpstan-wordpress-rules": "^0.2",
         "brain/monkey": "^2.6",
         "phpstan/extension-installer": "^1.4",

--- a/src/Admin/AdminNotice.php
+++ b/src/Admin/AdminNotice.php
@@ -13,7 +13,7 @@ class AdminNotice {
 	 * Create a new admin notice handler.
 	 */
 	public function __construct() {
-		add_action( 'admin_notices', [ $this, 'display_notices' ] );
+		\add_action( 'admin_notices', [ $this, 'display_notices' ] );
 	}
 
 	/**
@@ -22,29 +22,29 @@ class AdminNotice {
 	 * @return void
 	 */
 	public function display_notices(): void {
-		$user_id = get_current_user_id();
-		$notice  = get_transient( 'ctg_notice_' . $user_id );
+		$user_id = \get_current_user_id();
+		$notice  = \get_transient( 'ctg_notice_' . $user_id );
 
 		if ( $notice === false ) {
 			return;
 		}
 
-		delete_transient( 'ctg_notice_' . $user_id );
+		\delete_transient( 'ctg_notice_' . $user_id );
 
 		if ( $notice === 'converted' ) {
-			printf(
+			\printf(
 				'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
-				esc_html__( 'Post successfully converted to blocks.', 'classic-to-gutenberg' ),
+				\esc_html__( 'Post successfully converted to blocks.', 'classic-to-gutenberg' ),
 			);
 			return;
 		}
 
-		if ( str_starts_with( (string) $notice, 'error:' ) ) {
-			$error_message = substr( (string) $notice, 6 );
-			printf(
+		if ( \str_starts_with( (string) $notice, 'error:' ) ) {
+			$error_message = \substr( (string) $notice, 6 );
+			\printf(
 				'<div class="notice notice-error is-dismissible"><p>%s %s</p></div>',
-				esc_html__( 'Conversion failed:', 'classic-to-gutenberg' ),
-				esc_html( $error_message ),
+				\esc_html__( 'Conversion failed:', 'classic-to-gutenberg' ),
+				\esc_html( $error_message ),
 			);
 		}
 	}

--- a/src/Admin/RowAction.php
+++ b/src/Admin/RowAction.php
@@ -28,10 +28,10 @@ class RowAction {
 	public function __construct( ContentConverter $converter ) {
 		$this->converter = $converter;
 
-		add_filter( 'post_row_actions', [ $this, 'add_row_actions' ], 10, 2 );
-		add_filter( 'page_row_actions', [ $this, 'add_row_actions' ], 10, 2 );
-		add_action( 'admin_post_ctg_convert', [ $this, 'handle_convert' ] );
-		add_action( 'admin_post_ctg_preview', [ $this, 'handle_preview' ] );
+		\add_filter( 'post_row_actions', [ $this, 'add_row_actions' ], 10, 2 );
+		\add_filter( 'page_row_actions', [ $this, 'add_row_actions' ], 10, 2 );
+		\add_action( 'admin_post_ctg_convert', [ $this, 'handle_convert' ] );
+		\add_action( 'admin_post_ctg_preview', [ $this, 'handle_preview' ] );
 	}
 
 	/**
@@ -47,30 +47,30 @@ class RowAction {
 			return $actions;
 		}
 
-		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+		if ( ! \current_user_can( 'edit_post', $post->ID ) ) {
 			return $actions;
 		}
 
-		$convert_url = wp_nonce_url(
-			admin_url( 'admin-post.php?action=ctg_convert&post_id=' . $post->ID ),
+		$convert_url = \wp_nonce_url(
+			\admin_url( 'admin-post.php?action=ctg_convert&post_id=' . $post->ID ),
 			'ctg_convert_' . $post->ID,
 		);
 
-		$preview_url = wp_nonce_url(
-			admin_url( 'admin-post.php?action=ctg_preview&post_id=' . $post->ID ),
+		$preview_url = \wp_nonce_url(
+			\admin_url( 'admin-post.php?action=ctg_preview&post_id=' . $post->ID ),
 			'ctg_preview_' . $post->ID,
 		);
 
-		$actions['ctg_convert'] = sprintf(
+		$actions['ctg_convert'] = \sprintf(
 			'<a href="%s">%s</a>',
-			esc_url( $convert_url ),
-			esc_html__( 'Convert to Blocks', 'classic-to-gutenberg' ),
+			\esc_url( $convert_url ),
+			\esc_html__( 'Convert to Blocks', 'classic-to-gutenberg' ),
 		);
 
-		$actions['ctg_preview'] = sprintf(
+		$actions['ctg_preview'] = \sprintf(
 			'<a href="%s">%s</a>',
-			esc_url( $preview_url ),
-			esc_html__( 'Preview Blocks', 'classic-to-gutenberg' ),
+			\esc_url( $preview_url ),
+			\esc_html__( 'Preview Blocks', 'classic-to-gutenberg' ),
 		);
 
 		return $actions;
@@ -82,30 +82,30 @@ class RowAction {
 	 * @return void
 	 */
 	public function handle_convert(): void {
-		$post_id = isset( $_GET['post_id'] ) ? absint( wp_unslash( $_GET['post_id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce checked below
+		$post_id = isset( $_GET['post_id'] ) ? \absint( \wp_unslash( $_GET['post_id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce checked below
 
-		check_admin_referer( 'ctg_convert_' . $post_id );
+		\check_admin_referer( 'ctg_convert_' . $post_id );
 
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			wp_die( esc_html__( 'You do not have permission to convert this post.', 'classic-to-gutenberg' ) );
+		if ( ! \current_user_can( 'edit_post', $post_id ) ) {
+			\wp_die( \esc_html__( 'You do not have permission to convert this post.', 'classic-to-gutenberg' ) );
 		}
 
 		$runner = new MigrationRunner( $this->converter );
 		$result = $runner->convert_post( $post_id );
 
-		$redirect = admin_url( 'edit.php' );
-		$post     = get_post( $post_id );
+		$redirect = \admin_url( 'edit.php' );
+		$post     = \get_post( $post_id );
 		if ( $post !== null ) {
-			$redirect = admin_url( 'edit.php?post_type=' . $post->post_type );
+			$redirect = \admin_url( 'edit.php?post_type=' . $post->post_type );
 		}
 
 		if ( $result->success ) {
-			set_transient( 'ctg_notice_' . get_current_user_id(), 'converted', 30 );
+			\set_transient( 'ctg_notice_' . \get_current_user_id(), 'converted', 30 );
 		} else {
-			set_transient( 'ctg_notice_' . get_current_user_id(), 'error:' . $result->error, 30 );
+			\set_transient( 'ctg_notice_' . \get_current_user_id(), 'error:' . $result->error, 30 );
 		}
 
-		wp_safe_redirect( $redirect );
+		\wp_safe_redirect( $redirect );
 		exit();
 	}
 
@@ -115,26 +115,26 @@ class RowAction {
 	 * @return void
 	 */
 	public function handle_preview(): void {
-		$post_id = isset( $_GET['post_id'] ) ? absint( wp_unslash( $_GET['post_id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce checked below
+		$post_id = isset( $_GET['post_id'] ) ? \absint( \wp_unslash( $_GET['post_id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- nonce checked below
 
-		check_admin_referer( 'ctg_preview_' . $post_id );
+		\check_admin_referer( 'ctg_preview_' . $post_id );
 
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			wp_die( esc_html__( 'You do not have permission to preview this post.', 'classic-to-gutenberg' ) );
+		if ( ! \current_user_can( 'edit_post', $post_id ) ) {
+			\wp_die( \esc_html__( 'You do not have permission to preview this post.', 'classic-to-gutenberg' ) );
 		}
 
 		$runner = new MigrationRunner( $this->converter );
 		$result = $runner->convert_post( $post_id, true );
 
 		if ( ! $result->success ) {
-			wp_die( esc_html( $result->error ) );
+			\wp_die( \esc_html( $result->error ) );
 		}
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- block markup preview
-		echo '<html><head><title>Block Preview — Post #' . esc_html( (string) $post_id ) . '</title></head><body>';
-		echo '<h1>' . esc_html__( 'Block Preview', 'classic-to-gutenberg' ) . '</h1>';
+		echo '<html><head><title>Block Preview — Post #' . \esc_html( (string) $post_id ) . '</title></head><body>';
+		echo '<h1>' . \esc_html__( 'Block Preview', 'classic-to-gutenberg' ) . '</h1>';
 		echo '<pre style="white-space: pre-wrap; word-wrap: break-word;">';
-		echo esc_html( $result->converted );
+		echo \esc_html( $result->converted );
 		echo '</pre></body></html>';
 		exit();
 	}
@@ -147,6 +147,6 @@ class RowAction {
 	 * @return bool
 	 */
 	private function has_blocks( WP_Post $post ): bool {
-		return str_contains( $post->post_content, '<!-- wp:' );
+		return \str_contains( $post->post_content, '<!-- wp:' );
 	}
 }

--- a/src/CLI/ConvertCommand.php
+++ b/src/CLI/ConvertCommand.php
@@ -100,9 +100,9 @@ class ConvertCommand {
 
 		$post_ids = [];
 		foreach ( $args as $argument ) {
-			foreach ( explode( ',', $argument ) as $part ) {
-				$part = trim( $part );
-				if ( $part !== '' && ctype_digit( $part ) ) {
+			foreach ( \explode( ',', $argument ) as $part ) {
+				$part = \trim( $part );
+				if ( $part !== '' && \ctype_digit( $part ) ) {
 					$post_ids[] = (int) $part;
 				}
 			}
@@ -123,7 +123,7 @@ class ConvertCommand {
 		$runner = new MigrationRunner( $this->converter );
 		$mode   = $dry_run ? 'Dry run' : 'Converting';
 
-		WP_CLI::log( sprintf( '%s %d post(s)...', $mode, count( $post_ids ) ) );
+		WP_CLI::log( \sprintf( '%s %d post(s)...', $mode, \count( $post_ids ) ) );
 
 		$results   = $runner->convert_batch( $post_ids, $dry_run );
 		$converted = 0;
@@ -131,16 +131,16 @@ class ConvertCommand {
 
 		foreach ( $results as $result ) {
 			if ( $result->success ) {
-				++$converted;
-				WP_CLI::log( sprintf( '  [OK] Post #%d', $result->post_id ) );
+				$converted++;
+				WP_CLI::log( \sprintf( '  [OK] Post #%d', $result->post_id ) );
 			} else {
-				++$failed;
-				WP_CLI::warning( sprintf( '  [FAIL] Post #%d: %s', $result->post_id, $result->error ) );
+				$failed++;
+				WP_CLI::warning( \sprintf( '  [FAIL] Post #%d: %s', $result->post_id, $result->error ) );
 			}
 		}
 
 		$prefix = $dry_run ? 'Would convert' : 'Converted';
-		WP_CLI::success( sprintf( '%s %d post(s), %d failed.', $prefix, $converted, $failed ) );
+		WP_CLI::success( \sprintf( '%s %d post(s), %d failed.', $prefix, $converted, $failed ) );
 	}
 
 	/**
@@ -158,7 +158,7 @@ class ConvertCommand {
 		$query_args = [ 'limit' => $batch_size ];
 
 		if ( isset( $assoc_args['post-type'] ) ) {
-			$query_args['post_type'] = explode( ',', $assoc_args['post-type'] );
+			$query_args['post_type'] = \explode( ',', $assoc_args['post-type'] );
 		}
 
 		$total = $finder->count( $query_args );
@@ -169,7 +169,7 @@ class ConvertCommand {
 		}
 
 		$mode = $dry_run ? 'Dry run' : 'Converting';
-		WP_CLI::log( sprintf( '%s %d classic post(s)...', $mode, $total ) );
+		WP_CLI::log( \sprintf( '%s %d classic post(s)...', $mode, $total ) );
 
 		$offset    = 0;
 		$converted = 0;
@@ -187,11 +187,11 @@ class ConvertCommand {
 
 			foreach ( $results as $result ) {
 				if ( $result->success ) {
-					++$converted;
-					WP_CLI::log( sprintf( '  [OK] Post #%d', $result->post_id ) );
+					$converted++;
+					WP_CLI::log( \sprintf( '  [OK] Post #%d', $result->post_id ) );
 				} else {
-					++$failed;
-					WP_CLI::warning( sprintf( '  [FAIL] Post #%d: %s', $result->post_id, $result->error ) );
+					$failed++;
+					WP_CLI::warning( \sprintf( '  [FAIL] Post #%d: %s', $result->post_id, $result->error ) );
 				}
 			}
 
@@ -199,6 +199,6 @@ class ConvertCommand {
 		}
 
 		$prefix = $dry_run ? 'Would convert' : 'Converted';
-		WP_CLI::success( sprintf( '%s %d post(s), %d failed.', $prefix, $converted, $failed ) );
+		WP_CLI::success( \sprintf( '%s %d post(s), %d failed.', $prefix, $converted, $failed ) );
 	}
 }

--- a/src/CLI/RollbackCommand.php
+++ b/src/CLI/RollbackCommand.php
@@ -45,9 +45,9 @@ class RollbackCommand {
 		$result   = $rollback->rollback( $post_id );
 
 		if ( $result->success ) {
-			WP_CLI::success( sprintf( 'Post #%d rolled back successfully.', $post_id ) );
+			WP_CLI::success( \sprintf( 'Post #%d rolled back successfully.', $post_id ) );
 		} else {
-			WP_CLI::error( sprintf( 'Rollback failed for post #%d: %s', $post_id, $result->error ) );
+			WP_CLI::error( \sprintf( 'Rollback failed for post #%d: %s', $post_id, $result->error ) );
 		}
 	}
 }

--- a/src/CLI/StatusCommand.php
+++ b/src/CLI/StatusCommand.php
@@ -44,7 +44,7 @@ class StatusCommand {
 		$query_args = [];
 
 		if ( isset( $assoc_args['post-type'] ) ) {
-			$query_args['post_type'] = explode( ',', $assoc_args['post-type'] );
+			$query_args['post_type'] = \explode( ',', $assoc_args['post-type'] );
 		}
 
 		$total = $finder->count( $query_args );
@@ -54,6 +54,6 @@ class StatusCommand {
 			return;
 		}
 
-		WP_CLI::log( sprintf( 'Found %d classic post(s) without block markup.', $total ) );
+		WP_CLI::log( \sprintf( 'Found %d classic post(s) without block markup.', $total ) );
 	}
 }

--- a/src/ContentConverter.php
+++ b/src/ContentConverter.php
@@ -65,7 +65,7 @@ class ContentConverter {
 		 *
 		 * @return string
 		 */
-		$content = apply_filters( 'classic_to_gutenberg_pre_convert', $content );
+		$content = \apply_filters( 'classic_to_gutenberg_pre_convert', $content );
 
 		$placeholders = [];
 		$content      = $this->extract_special_comments( $content, $placeholders );
@@ -83,7 +83,7 @@ class ContentConverter {
 			$blocks[]  = $converter->convert( $element->html );
 		}
 
-		$result = implode( "\n\n", $blocks );
+		$result = \implode( "\n\n", $blocks );
 
 		/**
 		 * Filter content after the conversion pipeline.
@@ -94,7 +94,7 @@ class ContentConverter {
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'classic_to_gutenberg_post_convert', $result );
+		return \apply_filters( 'classic_to_gutenberg_post_convert', $result );
 	}
 
 	/**
@@ -108,12 +108,12 @@ class ContentConverter {
 	private function extract_special_comments( string $content, array &$placeholders ): string {
 		$index = 0;
 
-		return (string) preg_replace_callback(
+		return (string) \preg_replace_callback(
 			'/<!--(more|nextpage)-->/',
 			static function ( array $matches ) use ( &$placeholders, &$index ): string {
 				$key                  = '%%CTG_PLACEHOLDER_' . $index . '%%';
 				$placeholders[ $key ] = $matches[0];
-				++$index;
+				$index++;
 				return $key;
 			},
 			$content,
@@ -130,7 +130,7 @@ class ContentConverter {
 	 */
 	private function restore_special_comments( string $content, array $placeholders ): string {
 		foreach ( $placeholders as $key => $original ) {
-			$content = str_replace(
+			$content = \str_replace(
 				[ '<p>' . $key . '</p>', $key ],
 				[ $original, $original ],
 				$content,
@@ -185,13 +185,13 @@ class ContentConverter {
 	 * @return TopLevelElement|null Re-tagged shortcode element, or null.
 	 */
 	private function try_retag_shortcode( TopLevelElement $element ): ?TopLevelElement {
-		$inner = trim( strip_tags( $element->html, '<img><a>' ) );
+		$inner = \trim( \strip_tags( $element->html, '<img><a>' ) );
 
-		if ( ! preg_match( '/^\[(\w[\w-]*)/', $inner ) ) {
+		if ( ! \preg_match( '/^\[(\w[\w-]*)/', $inner ) ) {
 			return null;
 		}
 
-		if ( ! preg_match( '/\[(\w[\w-]*)(?:\s[^\]]*)?\](?:.*?\[\/\1\])?/s', $element->html, $match ) ) {
+		if ( ! \preg_match( '/\[(\w[\w-]*)(?:\s[^\]]*)?\](?:.*?\[\/\1\])?/s', $element->html, $match ) ) {
 			return null;
 		}
 
@@ -206,19 +206,19 @@ class ContentConverter {
 	 * @return TopLevelElement|null Re-tagged image element, or null.
 	 */
 	private function try_retag_image( TopLevelElement $element ): ?TopLevelElement {
-		if ( ! preg_match( '/^<p[^>]*>\s*(?:<a\s[^>]*>)?\s*<img\s/', $element->html ) ) {
+		if ( ! \preg_match( '/^<p[^>]*>\s*(?:<a\s[^>]*>)?\s*<img\s/', $element->html ) ) {
 			return null;
 		}
 
-		$stripped = (string) preg_replace( '/<\/a>/', '', $element->html );
-		if ( preg_match( '/[^<>]\s*<\/p>/', $stripped ) ) {
+		$stripped = (string) \preg_replace( '/<\/a>/', '', $element->html );
+		if ( \preg_match( '/[^<>]\s*<\/p>/', $stripped ) ) {
 			return null;
 		}
 
-		if ( ! preg_match( '/(?:<a\s[^>]*>)?\s*<img\s[^>]*\/?>\s*(?:<\/a>)?/i', $element->html, $match ) ) {
+		if ( ! \preg_match( '/(?:<a\s[^>]*>)?\s*<img\s[^>]*\/?>\s*(?:<\/a>)?/i', $element->html, $match ) ) {
 			return null;
 		}
 
-		return new TopLevelElement( 'img', trim( $match[0] ) );
+		return new TopLevelElement( 'img', \trim( $match[0] ) );
 	}
 }

--- a/src/Converter/AbstractBlockConverter.php
+++ b/src/Converter/AbstractBlockConverter.php
@@ -18,7 +18,7 @@ abstract class AbstractBlockConverter implements BlockConverterInterface {
 	 * @return bool
 	 */
 	public function can_convert( string $tag_name, string $html ): bool {
-		return in_array( $tag_name, $this->get_supported_tags(), true );
+		return \in_array( $tag_name, $this->get_supported_tags(), true );
 	}
 
 	/**
@@ -31,7 +31,7 @@ abstract class AbstractBlockConverter implements BlockConverterInterface {
 	 * @return string
 	 */
 	protected function wrap_block( string $block_name, string $content, array $attrs = [] ): string {
-		$attrs_string = $attrs !== [] ? ' ' . wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : '';
+		$attrs_string = $attrs !== [] ? ' ' . \wp_json_encode( $attrs, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE ) : '';
 
 		return "<!-- wp:{$block_name}{$attrs_string} -->\n{$content}\n<!-- /wp:{$block_name} -->";
 	}
@@ -45,7 +45,7 @@ abstract class AbstractBlockConverter implements BlockConverterInterface {
 	 * @return string
 	 */
 	protected function self_closing_block( string $block_name, array $attrs = [] ): string {
-		$attrs_string = $attrs !== [] ? ' ' . wp_json_encode( $attrs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) : '';
+		$attrs_string = $attrs !== [] ? ' ' . \wp_json_encode( $attrs, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE ) : '';
 
 		return "<!-- wp:{$block_name}{$attrs_string} /-->";
 	}

--- a/src/Converter/BlockConverterFactory.php
+++ b/src/Converter/BlockConverterFactory.php
@@ -47,7 +47,7 @@ class BlockConverterFactory {
 	 */
 	public function register( BlockConverterInterface $converter ): void {
 		foreach ( $converter->get_supported_tags() as $tag ) {
-			$this->converters[ strtolower( $tag ) ] = $converter;
+			$this->converters[ \strtolower( $tag ) ] = $converter;
 		}
 	}
 
@@ -60,7 +60,7 @@ class BlockConverterFactory {
 	 * @return BlockConverterInterface
 	 */
 	public function get_converter( string $tag_name, string $html ): BlockConverterInterface {
-		$tag = strtolower( $tag_name );
+		$tag = \strtolower( $tag_name );
 
 		if ( isset( $this->converters[ $tag ] ) && $this->converters[ $tag ]->can_convert( $tag, $html ) ) {
 			return $this->converters[ $tag ];

--- a/src/Converter/HeadingConverter.php
+++ b/src/Converter/HeadingConverter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Apermo\ClassicToGutenberg\Converter;
 
+use WP_HTML_Tag_Processor;
+
 /**
  * Converts <h1>-<h6> tags to core/heading blocks.
  */
@@ -24,11 +26,11 @@ class HeadingConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	public function convert( string $html ): string {
-		preg_match( '/<(h([1-6]))/i', $html, $match );
-		$tag_name = strtolower( $match[1] );
+		\preg_match( '/<(h([1-6]))/i', $html, $match );
+		$tag_name = \strtolower( $match[1] );
 		$level    = (int) $match[2];
 
-		$processor = new \WP_HTML_Tag_Processor( $html );
+		$processor = new WP_HTML_Tag_Processor( $html );
 		if ( $processor->next_tag( [ 'tag_name' => $tag_name ] ) ) {
 			$existing = $processor->get_attribute( 'class' );
 			$classes  = $existing !== null ? $existing . ' wp-block-heading' : 'wp-block-heading';

--- a/src/Converter/ImageConverter.php
+++ b/src/Converter/ImageConverter.php
@@ -35,7 +35,7 @@ class ImageConverter extends AbstractBlockConverter {
 		}
 
 		if ( $tag_name === 'figure' ) {
-			return (bool) preg_match( '/<img\s/i', $html );
+			return (bool) \preg_match( '/<img\s/i', $html );
 		}
 
 		return true;
@@ -49,11 +49,11 @@ class ImageConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	public function convert( string $html ): string {
-		if ( preg_match( '/^\s*<figure/i', $html ) ) {
+		if ( \preg_match( '/^\s*<figure/i', $html ) ) {
 			return $this->convert_figure( $html );
 		}
 
-		if ( preg_match( '/^\s*<a\s/i', $html ) ) {
+		if ( \preg_match( '/^\s*<a\s/i', $html ) ) {
 			return $this->convert_linked_image( $html );
 		}
 
@@ -84,13 +84,13 @@ class ImageConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	private function convert_linked_image( string $html ): string {
-		preg_match( '/<img\s[^>]*\/?>/i', $html, $img_match );
+		\preg_match( '/<img\s[^>]*\/?>/i', $html, $img_match );
 		$attrs                    = $this->extract_image_attrs( $img_match[0] );
 		$attrs['linkDestination'] = 'custom';
 
 		$clean_img = $this->build_clean_img( $img_match[0] );
 
-		preg_match( '/<a\s[^>]*>/i', $html, $link_match );
+		\preg_match( '/<a\s[^>]*>/i', $html, $link_match );
 		$link_open = $link_match[0];
 
 		$figure = '<figure class="wp-block-image' . $this->align_class( $attrs ) . '">'
@@ -107,11 +107,11 @@ class ImageConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	private function convert_figure( string $html ): string {
-		preg_match( '/<img\s[^>]*\/?>/i', $html, $img_match );
+		\preg_match( '/<img\s[^>]*\/?>/i', $html, $img_match );
 		$img_attrs = $this->extract_image_attrs( $img_match[0] );
 
 		$align = '';
-		if ( preg_match( '/class="[^"]*align(left|right|center|none)[^"]*"/', $html, $align_match ) ) {
+		if ( \preg_match( '/class="[^"]*align(left|right|center|none)[^"]*"/', $html, $align_match ) ) {
 			$align = $align_match[1];
 		}
 
@@ -120,7 +120,7 @@ class ImageConverter extends AbstractBlockConverter {
 		$clean_img = $this->build_clean_img( $img_match[0] );
 
 		$caption = '';
-		if ( preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $html, $cap_match ) ) {
+		if ( \preg_match( '/<figcaption[^>]*>(.*?)<\/figcaption>/s', $html, $cap_match ) ) {
 			$caption = '<figcaption class="wp-element-caption">' . $cap_match[1] . '</figcaption>';
 		}
 
@@ -172,18 +172,18 @@ class ImageConverter extends AbstractBlockConverter {
 	private function extract_image_attrs( string $img_html ): array {
 		$attrs = [];
 
-		if ( preg_match( '/wp-image-(\d+)/', $img_html, $match ) ) {
+		if ( \preg_match( '/wp-image-(\d+)/', $img_html, $match ) ) {
 			$attrs['id'] = (int) $match[1];
 		}
 
-		if ( preg_match( '/\balign(left|right|center|none)\b/', $img_html, $match ) ) {
+		if ( \preg_match( '/\balign(left|right|center|none)\b/', $img_html, $match ) ) {
 			$attrs['align'] = $match[1];
 		}
 
-		if ( preg_match( '/\bwidth=["\'](\d+)["\']/', $img_html, $match ) ) {
+		if ( \preg_match( '/\bwidth=["\'](\d+)["\']/', $img_html, $match ) ) {
 			$attrs['width'] = (int) $match[1];
 		}
-		if ( preg_match( '/\bheight=["\'](\d+)["\']/', $img_html, $match ) ) {
+		if ( \preg_match( '/\bheight=["\'](\d+)["\']/', $img_html, $match ) ) {
 			$attrs['height'] = (int) $match[1];
 		}
 
@@ -198,10 +198,10 @@ class ImageConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	private function build_clean_img( string $img_html ): string {
-		$clean = (string) preg_replace( '/\s*\balign(?:left|right|center|none)\b/', '', $img_html );
-		$clean = (string) preg_replace( '/\s*\/?\s*>$/', '/>', $clean );
-		$clean = (string) preg_replace( '/class="(\s+)/', 'class="', $clean );
-		$clean = (string) preg_replace( '/\s+"/', '"', $clean );
+		$clean = (string) \preg_replace( '/\s*\balign(?:left|right|center|none)\b/', '', $img_html );
+		$clean = (string) \preg_replace( '/\s*\/?\s*>$/', '/>', $clean );
+		$clean = (string) \preg_replace( '/class="(\s+)/', 'class="', $clean );
+		$clean = (string) \preg_replace( '/\s+"/', '"', $clean );
 
 		return $clean;
 	}

--- a/src/Converter/ListConverter.php
+++ b/src/Converter/ListConverter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Apermo\ClassicToGutenberg\Converter;
 
+use WP_HTML_Tag_Processor;
+
 /**
  * Converts <ul>/<ol> tags to core/list blocks with nested list-item inner blocks.
  */
@@ -30,7 +32,7 @@ class ListConverter extends AbstractBlockConverter {
 		}
 
 		$close_tag = '</' . $tag_name . '>';
-		return stripos( $html, $close_tag ) !== false;
+		return \stripos( $html, $close_tag ) !== false;
 	}
 
 	/**
@@ -41,7 +43,7 @@ class ListConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	public function convert( string $html ): string {
-		$is_ordered = (bool) preg_match( '/^\s*<ol/i', $html );
+		$is_ordered = (bool) \preg_match( '/^\s*<ol/i', $html );
 		$attrs      = $is_ordered ? [ 'ordered' => true ] : [];
 
 		$inner = $this->convert_list( $html, $is_ordered );
@@ -60,7 +62,7 @@ class ListConverter extends AbstractBlockConverter {
 	private function convert_list( string $html, bool $is_ordered ): string {
 		$tag_name = $is_ordered ? 'ol' : 'ul';
 
-		$processor = new \WP_HTML_Tag_Processor( $html );
+		$processor = new WP_HTML_Tag_Processor( $html );
 		if ( $processor->next_tag( [ 'tag_name' => $tag_name ] ) ) {
 			$existing = $processor->get_attribute( 'class' );
 			$classes  = $existing !== null ? $existing . ' wp-block-list' : 'wp-block-list';
@@ -79,8 +81,8 @@ class ListConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	private function wrap_list_items( string $html ): string {
-		preg_match( '/^(<(?:ul|ol)(?:\s[^>]*)?>)\s*/i', $html, $open_match );
-		preg_match( '/\s*(<\/(?:ul|ol)\s*>)\s*$/i', $html, $close_match );
+		\preg_match( '/^(<(?:ul|ol)(?:\s[^>]*)?>)\s*/i', $html, $open_match );
+		\preg_match( '/\s*(<\/(?:ul|ol)\s*>)\s*$/i', $html, $close_match );
 
 		$open_tag  = $open_match[1];
 		$close_tag = $close_match[1];
@@ -92,7 +94,7 @@ class ListConverter extends AbstractBlockConverter {
 			$items[] = $this->convert_list_item_content( $content );
 		}
 
-		return $open_tag . implode( "\n\n", $items ) . $close_tag;
+		return $open_tag . \implode( "\n\n", $items ) . $close_tag;
 	}
 
 	/**
@@ -105,19 +107,19 @@ class ListConverter extends AbstractBlockConverter {
 	private function extract_list_items( string $html ): array {
 		$items  = [];
 		$offset = 0;
-		$length = strlen( $html );
+		$length = \strlen( $html );
 
 		while ( $offset < $length ) {
-			if ( ! preg_match( '/<li(?:\s[^>]*)?>/', $html, $match, PREG_OFFSET_CAPTURE, $offset ) ) {
+			if ( ! \preg_match( '/<li(?:\s[^>]*)?>/', $html, $match, \PREG_OFFSET_CAPTURE, $offset ) ) {
 				break;
 			}
 
 			$li_start      = $match[0][1];
-			$content_start = $li_start + strlen( $match[0][0] );
+			$content_start = $li_start + \strlen( $match[0][0] );
 			$content_end   = $this->find_closing_li( $html, $content_start );
 
-			$items[] = substr( $html, $content_start, $content_end - $content_start );
-			$offset  = $content_end + strlen( '</li>' );
+			$items[] = \substr( $html, $content_start, $content_end - $content_start );
+			$offset  = $content_end + \strlen( '</li>' );
 		}
 
 		return $items;
@@ -135,26 +137,26 @@ class ListConverter extends AbstractBlockConverter {
 	 */
 	private function find_closing_li( string $html, int $offset ): int {
 		$depth  = 1;
-		$length = strlen( $html );
+		$length = \strlen( $html );
 
 		while ( $offset < $length && $depth > 0 ) {
-			if ( ! preg_match( '/<li(?:\s[^>]*)?>|<\/li\s*>/i', $html, $match, PREG_OFFSET_CAPTURE, $offset ) ) {
+			if ( ! \preg_match( '/<li(?:\s[^>]*)?>|<\/li\s*>/i', $html, $match, \PREG_OFFSET_CAPTURE, $offset ) ) {
 				return $length;
 			}
 
 			$match_str    = $match[0][0];
 			$match_offset = $match[0][1];
 
-			if ( stripos( $match_str, '</li' ) === 0 ) {
-				--$depth;
+			if ( \stripos( $match_str, '</li' ) === 0 ) {
+				$depth--;
 				if ( $depth === 0 ) {
 					return $match_offset;
 				}
 			} else {
-				++$depth;
+				$depth++;
 			}
 
-			$offset = $match_offset + strlen( $match_str );
+			$offset = $match_offset + \strlen( $match_str );
 		}
 
 		return $length;
@@ -168,7 +170,7 @@ class ListConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	private function convert_list_item_content( string $content ): string {
-		$content = (string) preg_replace_callback(
+		$content = (string) \preg_replace_callback(
 			'/\s*<(ul|ol)(?:\s[^>]*)?>[\s\S]*?<\/\1\s*>\s*/i',
 			[ $this, 'convert_nested_list' ],
 			$content,
@@ -185,10 +187,10 @@ class ListConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	private function convert_nested_list( array $matches ): string {
-		$nested_tag = strtolower( $matches[1] );
+		$nested_tag = \strtolower( $matches[1] );
 		$is_ordered = $nested_tag === 'ol';
 		$attrs      = $is_ordered ? [ 'ordered' => true ] : [];
-		$inner      = $this->convert_list( trim( $matches[0] ), $is_ordered );
+		$inner      = $this->convert_list( \trim( $matches[0] ), $is_ordered );
 
 		return $this->wrap_block( 'list', $inner, $attrs );
 	}

--- a/src/Converter/PreformattedConverter.php
+++ b/src/Converter/PreformattedConverter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Apermo\ClassicToGutenberg\Converter;
 
+use WP_HTML_Tag_Processor;
+
 /**
  * Converts <pre> tags to core/preformatted blocks.
  */
@@ -24,7 +26,7 @@ class PreformattedConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	public function convert( string $html ): string {
-		$processor = new \WP_HTML_Tag_Processor( $html );
+		$processor = new WP_HTML_Tag_Processor( $html );
 		if ( $processor->next_tag( [ 'tag_name' => 'pre' ] ) ) {
 			$existing = $processor->get_attribute( 'class' );
 			$classes  = $existing !== null ? $existing . ' wp-block-preformatted' : 'wp-block-preformatted';

--- a/src/Converter/QuoteConverter.php
+++ b/src/Converter/QuoteConverter.php
@@ -24,8 +24,8 @@ class QuoteConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	public function convert( string $html ): string {
-		preg_match( '/<blockquote(?:\s[^>]*)?>(.*)<\/blockquote>/s', $html, $match );
-		$inner = trim( $match[1] );
+		\preg_match( '/<blockquote(?:\s[^>]*)?>(.*)<\/blockquote>/s', $html, $match );
+		$inner = \trim( $match[1] );
 
 		$converted_inner = $this->convert_inner_content( $inner );
 		$content         = '<blockquote class="wp-block-quote">' . $converted_inner . '</blockquote>';
@@ -44,11 +44,11 @@ class QuoteConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	private function convert_inner_content( string $inner ): string {
-		$parts = preg_split(
+		$parts = \preg_split(
 			'/(<p(?:\s[^>]*)?>.*?<\/p>|<cite>.*?<\/cite>)/s',
 			$inner,
 			-1,
-			PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY,
+			\PREG_SPLIT_DELIM_CAPTURE | \PREG_SPLIT_NO_EMPTY,
 		);
 
 		if ( $parts === false ) {
@@ -59,7 +59,7 @@ class QuoteConverter extends AbstractBlockConverter {
 		$prev_was_paragraph = false;
 
 		foreach ( $parts as $part ) {
-			$part = trim( $part );
+			$part = \trim( $part );
 			if ( $part === '' ) {
 				continue;
 			}
@@ -67,7 +67,7 @@ class QuoteConverter extends AbstractBlockConverter {
 			if ( $this->is_cite_paragraph( $part ) ) {
 				$result .= $this->extract_cite( $part );
 				$prev_was_paragraph = false;
-			} elseif ( preg_match( '/^<p(?:\s[^>]*)?>.*<\/p>$/s', $part ) ) {
+			} elseif ( \preg_match( '/^<p(?:\s[^>]*)?>.*<\/p>$/s', $part ) ) {
 				if ( $prev_was_paragraph ) {
 					$result .= "\n\n";
 				}
@@ -92,7 +92,7 @@ class QuoteConverter extends AbstractBlockConverter {
 	 * @return bool
 	 */
 	private function is_cite_paragraph( string $part ): bool {
-		return (bool) preg_match( '/^<p(?:\s[^>]*)?>\s*<cite>.*?<\/cite>\s*<\/p>$/s', $part );
+		return (bool) \preg_match( '/^<p(?:\s[^>]*)?>\s*<cite>.*?<\/cite>\s*<\/p>$/s', $part );
 	}
 
 	/**
@@ -103,7 +103,7 @@ class QuoteConverter extends AbstractBlockConverter {
 	 * @return string The bare <cite>...</cite> element.
 	 */
 	private function extract_cite( string $part ): string {
-		if ( preg_match( '/<cite>.*?<\/cite>/s', $part, $match ) ) {
+		if ( \preg_match( '/<cite>.*?<\/cite>/s', $part, $match ) ) {
 			return $match[0];
 		}
 		return $part;

--- a/src/Converter/Shortcode/CaptionHandler.php
+++ b/src/Converter/Shortcode/CaptionHandler.php
@@ -45,7 +45,7 @@ class CaptionHandler implements ShortcodeHandlerInterface {
 		$figure = '<figure class="wp-block-image' . $align_class . '">'
 			. $clean_img . $caption_html . '</figure>';
 
-		return '<!-- wp:image ' . wp_json_encode( $block_attrs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . " -->\n"
+		return '<!-- wp:image ' . \wp_json_encode( $block_attrs, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE ) . " -->\n"
 			. $figure . "\n"
 			. '<!-- /wp:image -->';
 	}
@@ -59,8 +59,8 @@ class CaptionHandler implements ShortcodeHandlerInterface {
 	 */
 	private function parse_attrs( string $shortcode ): array {
 		$attrs = [];
-		if ( preg_match( '/\[caption([^\]]*)\]/', $shortcode, $match ) ) {
-			preg_match_all( '/(\w+)=["\']([^"\']*)["\']/', $match[1], $attr_matches, PREG_SET_ORDER );
+		if ( \preg_match( '/\[caption([^\]]*)\]/', $shortcode, $match ) ) {
+			\preg_match_all( '/(\w+)=["\']([^"\']*)["\']/', $match[1], $attr_matches, \PREG_SET_ORDER );
 			foreach ( $attr_matches as $attr ) {
 				$attrs[ $attr[1] ] = $attr[2];
 			}
@@ -76,7 +76,7 @@ class CaptionHandler implements ShortcodeHandlerInterface {
 	 * @return string
 	 */
 	private function extract_img( string $shortcode ): string {
-		preg_match( '/<img\s[^>]*\/?>/i', $shortcode, $match );
+		\preg_match( '/<img\s[^>]*\/?>/i', $shortcode, $match );
 		return $match[0] ?? '';
 	}
 
@@ -88,8 +88,8 @@ class CaptionHandler implements ShortcodeHandlerInterface {
 	 * @return string
 	 */
 	private function extract_caption_text( string $shortcode ): string {
-		if ( preg_match( '/<img\s[^>]*\/?>\s*(.*?)\s*\[\/caption\]/s', $shortcode, $match ) ) {
-			return trim( $match[1] );
+		if ( \preg_match( '/<img\s[^>]*\/?>\s*(.*?)\s*\[\/caption\]/s', $shortcode, $match ) ) {
+			return \trim( $match[1] );
 		}
 		return '';
 	}
@@ -106,9 +106,9 @@ class CaptionHandler implements ShortcodeHandlerInterface {
 		$block_attrs = [];
 
 		// ID from shortcode (attachment_N format) or img class.
-		if ( isset( $attrs['id'] ) && preg_match( '/attachment_(\d+)/', $attrs['id'], $match ) ) {
+		if ( isset( $attrs['id'] ) && \preg_match( '/attachment_(\d+)/', $attrs['id'], $match ) ) {
 			$block_attrs['id'] = (int) $match[1];
-		} elseif ( preg_match( '/wp-image-(\d+)/', $img_tag, $match ) ) {
+		} elseif ( \preg_match( '/wp-image-(\d+)/', $img_tag, $match ) ) {
 			$block_attrs['id'] = (int) $match[1];
 		}
 
@@ -120,11 +120,11 @@ class CaptionHandler implements ShortcodeHandlerInterface {
 		// Width and height from shortcode attrs or img tag.
 		if ( isset( $attrs['width'] ) ) {
 			$block_attrs['width'] = (int) $attrs['width'];
-		} elseif ( preg_match( '/\bwidth=["\'](\d+)["\']/', $img_tag, $match ) ) {
+		} elseif ( \preg_match( '/\bwidth=["\'](\d+)["\']/', $img_tag, $match ) ) {
 			$block_attrs['width'] = (int) $match[1];
 		}
 
-		if ( preg_match( '/\bheight=["\'](\d+)["\']/', $img_tag, $match ) ) {
+		if ( \preg_match( '/\bheight=["\'](\d+)["\']/', $img_tag, $match ) ) {
 			$block_attrs['height'] = (int) $match[1];
 		}
 
@@ -140,7 +140,7 @@ class CaptionHandler implements ShortcodeHandlerInterface {
 	 */
 	private function extract_align( array $attrs ): string {
 		if ( isset( $attrs['align'] ) ) {
-			return str_replace( 'align', '', $attrs['align'] );
+			return \str_replace( 'align', '', $attrs['align'] );
 		}
 		return '';
 	}
@@ -153,6 +153,6 @@ class CaptionHandler implements ShortcodeHandlerInterface {
 	 * @return string
 	 */
 	private function build_clean_img( string $img_tag ): string {
-		return (string) preg_replace( '/\s*\/?\s*>$/', '/>', $img_tag );
+		return (string) \preg_replace( '/\s*\/?\s*>$/', '/>', $img_tag );
 	}
 }

--- a/src/Converter/Shortcode/GalleryHandler.php
+++ b/src/Converter/Shortcode/GalleryHandler.php
@@ -39,7 +39,7 @@ class GalleryHandler implements ShortcodeHandlerInterface {
 		$figure        = '<figure class="wp-block-gallery has-nested-images ' . $columns_class . '">'
 			. $inner_blocks . '</figure>';
 
-		return '<!-- wp:gallery ' . wp_json_encode( $block_attrs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . " -->\n"
+		return '<!-- wp:gallery ' . \wp_json_encode( $block_attrs, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE ) . " -->\n"
 			. $figure . "\n"
 			. '<!-- /wp:gallery -->';
 	}
@@ -53,8 +53,8 @@ class GalleryHandler implements ShortcodeHandlerInterface {
 	 */
 	private function parse_attrs( string $shortcode ): array {
 		$attrs = [];
-		if ( preg_match( '/\[gallery([^\]]*)\]/', $shortcode, $match ) ) {
-			preg_match_all( '/(\w+)=["\']([^"\']*)["\']/', $match[1], $attr_matches, PREG_SET_ORDER );
+		if ( \preg_match( '/\[gallery([^\]]*)\]/', $shortcode, $match ) ) {
+			\preg_match_all( '/(\w+)=["\']([^"\']*)["\']/', $match[1], $attr_matches, \PREG_SET_ORDER );
 			foreach ( $attr_matches as $attr ) {
 				$attrs[ $attr[1] ] = $attr[2];
 			}
@@ -74,7 +74,7 @@ class GalleryHandler implements ShortcodeHandlerInterface {
 			return [];
 		}
 
-		return array_map( 'intval', explode( ',', $attrs['ids'] ) );
+		return \array_map( 'intval', \explode( ',', $attrs['ids'] ) );
 	}
 
 	/**
@@ -109,13 +109,13 @@ class GalleryHandler implements ShortcodeHandlerInterface {
 				$img_attrs['linkDestination'] = $link_to;
 			}
 
-			$attrs_json = wp_json_encode( $img_attrs, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+			$attrs_json = \wp_json_encode( $img_attrs, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE );
 
 			$blocks[] = "<!-- wp:image {$attrs_json} -->\n"
 				. '<figure class="wp-block-image"><img src="" alt="" class="wp-image-' . $image_id . '"/></figure>' . "\n"
 				. '<!-- /wp:image -->';
 		}
 
-		return implode( "\n\n", $blocks );
+		return \implode( "\n\n", $blocks );
 	}
 }

--- a/src/Converter/ShortcodeConverter.php
+++ b/src/Converter/ShortcodeConverter.php
@@ -73,7 +73,7 @@ class ShortcodeConverter extends AbstractBlockConverter {
 	 * @return string The tag name, or empty string if not found.
 	 */
 	private function extract_shortcode_tag( string $shortcode ): string {
-		if ( preg_match( '/\[(\w[\w-]*)/', $shortcode, $match ) ) {
+		if ( \preg_match( '/\[(\w[\w-]*)/', $shortcode, $match ) ) {
 			return $match[1];
 		}
 		return '';

--- a/src/Converter/TableConverter.php
+++ b/src/Converter/TableConverter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Apermo\ClassicToGutenberg\Converter;
 
+use WP_HTML_Tag_Processor;
+
 /**
  * Converts <table> tags to core/table blocks.
  */
@@ -29,7 +31,7 @@ class TableConverter extends AbstractBlockConverter {
 			return false;
 		}
 
-		return (bool) preg_match( '/<thead/i', $html ) && (bool) preg_match( '/<tbody/i', $html );
+		return (bool) \preg_match( '/<thead/i', $html ) && (bool) \preg_match( '/<tbody/i', $html );
 	}
 
 	/**
@@ -42,7 +44,7 @@ class TableConverter extends AbstractBlockConverter {
 	public function convert( string $html ): string {
 		$collapsed = $this->collapse_whitespace( $html );
 
-		$processor = new \WP_HTML_Tag_Processor( $collapsed );
+		$processor = new WP_HTML_Tag_Processor( $collapsed );
 		if ( $processor->next_tag( [ 'tag_name' => 'table' ] ) ) {
 			$existing = $processor->get_attribute( 'class' );
 			$classes  = $existing !== null ? $existing . ' has-fixed-layout' : 'has-fixed-layout';
@@ -63,6 +65,6 @@ class TableConverter extends AbstractBlockConverter {
 	 * @return string
 	 */
 	private function collapse_whitespace( string $html ): string {
-		return (string) preg_replace( '/>\s+</', '><', $html );
+		return (string) \preg_replace( '/>\s+</', '><', $html );
 	}
 }

--- a/src/Migration/ClassicPostFinder.php
+++ b/src/Migration/ClassicPostFinder.php
@@ -36,15 +36,15 @@ class ClassicPostFinder {
 		 *
 		 * @return array<string, mixed>
 		 */
-		$filtered_args = apply_filters( 'classic_to_gutenberg_finder_args', $args, $defaults );
-		$args          = wp_parse_args( $filtered_args, $defaults );
+		$filtered_args = \apply_filters( 'classic_to_gutenberg_finder_args', $args, $defaults );
+		$args          = \wp_parse_args( $filtered_args, $defaults );
 
 		$post_types = (array) $args['post_type'];
 		$statuses   = (array) $args['post_status'];
 		$limit      = (int) $args['limit'];
 		$offset     = (int) $args['offset'];
-		$type_in    = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
-		$status_in  = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+		$type_in    = \implode( ',', \array_fill( 0, \count( $post_types ), '%s' ) );
+		$status_in  = \implode( ',', \array_fill( 0, \count( $statuses ), '%s' ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- dynamic IN clause
 		$query = $wpdb->prepare(
@@ -55,14 +55,14 @@ class ClassicPostFinder {
 			AND post_content != ''
 			ORDER BY ID ASC
 			LIMIT %d OFFSET %d",
-			...array_merge( $post_types, $statuses, [ '%<!-- wp:%', $limit, $offset ] ),
+			...\array_merge( $post_types, $statuses, [ '%<!-- wp:%', $limit, $offset ] ),
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- prepared above
 		$results = $wpdb->get_col( $query );
 
-		return array_map( 'intval', $results );
+		return \array_map( 'intval', $results );
 	}
 
 	/**
@@ -80,12 +80,12 @@ class ClassicPostFinder {
 			'post_status' => [ 'publish', 'draft', 'pending', 'future', 'private' ],
 		];
 
-		$args = wp_parse_args( $args, $defaults );
+		$args = \wp_parse_args( $args, $defaults );
 
 		$post_types = (array) $args['post_type'];
 		$statuses   = (array) $args['post_status'];
-		$type_in    = implode( ',', array_fill( 0, count( $post_types ), '%s' ) );
-		$status_in  = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+		$type_in    = \implode( ',', \array_fill( 0, \count( $post_types ), '%s' ) );
+		$status_in  = \implode( ',', \array_fill( 0, \count( $statuses ), '%s' ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- dynamic IN clause
 		$query = $wpdb->prepare(
@@ -94,7 +94,7 @@ class ClassicPostFinder {
 			AND post_status IN ({$status_in})
 			AND post_content NOT LIKE %s
 			AND post_content != ''",
-			...array_merge( $post_types, $statuses, [ '%<!-- wp:%' ] ),
+			...\array_merge( $post_types, $statuses, [ '%<!-- wp:%' ] ),
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 

--- a/src/Migration/MigrationRollback.php
+++ b/src/Migration/MigrationRollback.php
@@ -17,19 +17,19 @@ class MigrationRollback {
 	 * @return MigrationResult
 	 */
 	public function rollback( int $post_id ): MigrationResult {
-		$revision_id = (int) get_post_meta( $post_id, '_ctg_revision_id', true );
+		$revision_id = (int) \get_post_meta( $post_id, '_ctg_revision_id', true );
 
 		if ( $revision_id === 0 ) {
 			return new MigrationResult( $post_id, false, '', '', 'No conversion revision found.' );
 		}
 
-		$revision = get_post( $revision_id );
+		$revision = \get_post( $revision_id );
 
 		if ( $revision === null ) {
 			return new MigrationResult( $post_id, false, '', '', 'Revision not found.' );
 		}
 
-		$post = get_post( $post_id );
+		$post = \get_post( $post_id );
 
 		if ( $post === null ) {
 			return new MigrationResult( $post_id, false, '', '', 'Post not found.' );
@@ -38,7 +38,7 @@ class MigrationRollback {
 		$current  = $post->post_content;
 		$original = $revision->post_content;
 
-		$updated = wp_update_post(
+		$updated = \wp_update_post(
 			[
 				'ID'           => $post_id,
 				'post_content' => $original,
@@ -46,11 +46,11 @@ class MigrationRollback {
 			true,
 		);
 
-		if ( is_wp_error( $updated ) ) {
+		if ( \is_wp_error( $updated ) ) {
 			return new MigrationResult( $post_id, false, $current, '', $updated->get_error_message() );
 		}
 
-		delete_post_meta( $post_id, '_ctg_revision_id' );
+		\delete_post_meta( $post_id, '_ctg_revision_id' );
 
 		/**
 		 * Fires after a post has been rolled back.
@@ -60,7 +60,7 @@ class MigrationRollback {
 		 * @param int    $post_id  The post ID.
 		 * @param string $original The restored content.
 		 */
-		do_action( 'classic_to_gutenberg_post_rolled_back', $post_id, $original );
+		\do_action( 'classic_to_gutenberg_post_rolled_back', $post_id, $original );
 
 		return new MigrationResult( $post_id, true, $current, $original );
 	}

--- a/src/Migration/MigrationRunner.php
+++ b/src/Migration/MigrationRunner.php
@@ -36,7 +36,7 @@ class MigrationRunner {
 	 * @return MigrationResult
 	 */
 	public function convert_post( int $post_id, bool $dry_run = false ): MigrationResult {
-		$post = get_post( $post_id );
+		$post = \get_post( $post_id );
 
 		if ( $post === null ) {
 			return new MigrationResult( $post_id, false, '', '', 'Post not found.' );
@@ -50,9 +50,9 @@ class MigrationRunner {
 		}
 
 		// Save a revision with the classic content before converting.
-		$revision_id = wp_save_post_revision( $post_id );
+		$revision_id = \wp_save_post_revision( $post_id );
 
-		$updated = wp_update_post(
+		$updated = \wp_update_post(
 			[
 				'ID'           => $post_id,
 				'post_content' => $converted,
@@ -60,13 +60,13 @@ class MigrationRunner {
 			true,
 		);
 
-		if ( is_wp_error( $updated ) ) {
+		if ( \is_wp_error( $updated ) ) {
 			return new MigrationResult( $post_id, false, $original, $converted, $updated->get_error_message() );
 		}
 
 		// Store the pre-conversion revision ID for rollback.
-		if ( is_int( $revision_id ) && $revision_id > 0 ) {
-			update_post_meta( $post_id, '_ctg_revision_id', $revision_id );
+		if ( \is_int( $revision_id ) && $revision_id > 0 ) {
+			\update_post_meta( $post_id, '_ctg_revision_id', $revision_id );
 		}
 
 		/**
@@ -77,7 +77,7 @@ class MigrationRunner {
 		 * @param int             $post_id The post ID.
 		 * @param MigrationResult $result  The migration result.
 		 */
-		do_action( 'classic_to_gutenberg_post_converted', $post_id, new MigrationResult( $post_id, true, $original, $converted ) );
+		\do_action( 'classic_to_gutenberg_post_converted', $post_id, new MigrationResult( $post_id, true, $original, $converted ) );
 
 		return new MigrationResult( $post_id, true, $original, $converted );
 	}
@@ -99,7 +99,7 @@ class MigrationRunner {
 		 * @param int[] $post_ids The post IDs.
 		 * @param bool  $dry_run  Whether this is a dry run.
 		 */
-		do_action( 'classic_to_gutenberg_batch_started', $post_ids, $dry_run );
+		\do_action( 'classic_to_gutenberg_batch_started', $post_ids, $dry_run );
 
 		$results = [];
 		foreach ( $post_ids as $post_id ) {
@@ -114,7 +114,7 @@ class MigrationRunner {
 		 * @param MigrationResult[] $results The migration results.
 		 * @param bool              $dry_run Whether this was a dry run.
 		 */
-		do_action( 'classic_to_gutenberg_batch_completed', $results, $dry_run );
+		\do_action( 'classic_to_gutenberg_batch_completed', $results, $dry_run );
 
 		return $results;
 	}

--- a/src/Parser/TopLevelSplitter.php
+++ b/src/Parser/TopLevelSplitter.php
@@ -50,7 +50,7 @@ class TopLevelSplitter {
 		$html = $this->normalize_br( $html );
 
 		$elements = [];
-		$length   = strlen( $html );
+		$length   = \strlen( $html );
 		$offset   = 0;
 
 		while ( $offset < $length ) {
@@ -66,9 +66,9 @@ class TopLevelSplitter {
 
 			if ( $element !== null ) {
 				$elements[] = $element;
-				$offset     += strlen( $element->html );
+				$offset     += \strlen( $element->html );
 			} else {
-				++$offset;
+				$offset++;
 			}
 		}
 
@@ -84,8 +84,8 @@ class TopLevelSplitter {
 	 * @return int New position after whitespace.
 	 */
 	private function skip_whitespace( string $html, int $offset ): int {
-		if ( preg_match( '/\G\s+/', $html, $match, 0, $offset ) ) {
-			return $offset + strlen( $match[0] );
+		if ( \preg_match( '/\G\s+/', $html, $match, 0, $offset ) ) {
+			return $offset + \strlen( $match[0] );
 		}
 		return $offset;
 	}
@@ -99,11 +99,11 @@ class TopLevelSplitter {
 	 * @return TopLevelElement|null
 	 */
 	private function match_comment( string $html, int $offset ): ?TopLevelElement {
-		if ( preg_match( '/\G<!--more-->/i', $html, $match, 0, $offset ) ) {
+		if ( \preg_match( '/\G<!--more-->/i', $html, $match, 0, $offset ) ) {
 			return new TopLevelElement( '__more__', $match[0] );
 		}
 
-		if ( preg_match( '/\G<!--nextpage-->/i', $html, $match, 0, $offset ) ) {
+		if ( \preg_match( '/\G<!--nextpage-->/i', $html, $match, 0, $offset ) ) {
 			return new TopLevelElement( '__nextpage__', $match[0] );
 		}
 
@@ -119,7 +119,7 @@ class TopLevelSplitter {
 	 * @return TopLevelElement|null
 	 */
 	private function match_shortcode( string $html, int $offset ): ?TopLevelElement {
-		if ( preg_match( '/\G\[(\w[\w-]*)(?:\s[^\]]*)?\](?:.*?\[\/\1\])?/s', $html, $match, 0, $offset ) ) {
+		if ( \preg_match( '/\G\[(\w[\w-]*)(?:\s[^\]]*)?\](?:.*?\[\/\1\])?/s', $html, $match, 0, $offset ) ) {
 			return new TopLevelElement( '__shortcode__', $match[0] );
 		}
 
@@ -135,15 +135,15 @@ class TopLevelSplitter {
 	 * @return TopLevelElement|null
 	 */
 	private function match_block_tag( string $html, int $offset ): ?TopLevelElement {
-		$tags_pattern = implode( '|', self::BLOCK_TAGS );
+		$tags_pattern = \implode( '|', self::BLOCK_TAGS );
 
-		if ( ! preg_match( '/\G<(' . $tags_pattern . ')(?:\s[^>]*)?(?:\/>|>)/i', $html, $match, 0, $offset ) ) {
+		if ( ! \preg_match( '/\G<(' . $tags_pattern . ')(?:\s[^>]*)?(?:\/>|>)/i', $html, $match, 0, $offset ) ) {
 			return null;
 		}
 
-		$tag_name = strtolower( $match[1] );
+		$tag_name = \strtolower( $match[1] );
 
-		if ( in_array( $tag_name, self::VOID_TAGS, true ) ) {
+		if ( \in_array( $tag_name, self::VOID_TAGS, true ) ) {
 			return new TopLevelElement( $tag_name, $match[0] );
 		}
 
@@ -178,7 +178,7 @@ class TopLevelSplitter {
 	 * @return string
 	 */
 	private function normalize_br( string $html ): string {
-		return (string) preg_replace( '/<br\s*>/', '<br/>', $html );
+		return (string) \preg_replace( '/<br\s*>/', '<br/>', $html );
 	}
 
 	/**
@@ -194,39 +194,39 @@ class TopLevelSplitter {
 	 * @return string The complete element HTML.
 	 */
 	private function extract_element( string $html, int $offset, string $tag_name ): string {
-		$length = strlen( $html );
+		$length = \strlen( $html );
 
-		preg_match( '/\G<' . $tag_name . '(?:\s[^>]*)?>/', $html, $open_match, 0, $offset );
-		$search_pos   = $offset + strlen( $open_match[0] );
+		\preg_match( '/\G<' . $tag_name . '(?:\s[^>]*)?>/', $html, $open_match, 0, $offset );
+		$search_pos   = $offset + \strlen( $open_match[0] );
 		$depth        = 1;
 		$open_pattern = '/<' . $tag_name . '(?:\s[^>]*)?>|<\/' . $tag_name . '\s*>/i';
 
 		while ( $search_pos < $length && $depth > 0 ) {
-			if ( ! preg_match( $open_pattern, $html, $match, PREG_OFFSET_CAPTURE, $search_pos ) ) {
+			if ( ! \preg_match( $open_pattern, $html, $match, \PREG_OFFSET_CAPTURE, $search_pos ) ) {
 				return $this->extract_until_next_block( $html, $offset );
 			}
 
 			$match_str    = $match[0][0];
 			$match_offset = $match[0][1];
-			$is_closing   = str_starts_with( $match_str, '</' );
+			$is_closing   = \str_starts_with( $match_str, '</' );
 
 			if ( $is_closing ) {
-				--$depth;
+				$depth--;
 			} else {
 				if ( $tag_name === 'p' && $depth === 1 ) {
-					return substr( $html, $offset, $match_offset - $offset );
+					return \substr( $html, $offset, $match_offset - $offset );
 				}
-				++$depth;
+				$depth++;
 			}
 
-			$search_pos = $match_offset + strlen( $match_str );
+			$search_pos = $match_offset + \strlen( $match_str );
 		}
 
 		if ( $depth > 0 ) {
 			return $this->extract_until_next_block( $html, $offset );
 		}
 
-		return substr( $html, $offset, $search_pos - $offset );
+		return \substr( $html, $offset, $search_pos - $offset );
 	}
 
 	/**
@@ -240,18 +240,18 @@ class TopLevelSplitter {
 	 * @return string
 	 */
 	private function extract_until_next_block( string $html, int $offset ): string {
-		$tags_pattern = implode( '|', self::BLOCK_TAGS );
+		$tags_pattern = \implode( '|', self::BLOCK_TAGS );
 		$pattern      = '/(?<=\n|\s)<(?:' . $tags_pattern . ')(?:\s[^>]*)?(?:\/>|>)/i';
 
-		preg_match( '/\G<\w+(?:\s[^>]*)?>/', $html, $open_match, 0, $offset );
-		$after_open = $offset + strlen( $open_match[0] );
+		\preg_match( '/\G<\w+(?:\s[^>]*)?>/', $html, $open_match, 0, $offset );
+		$after_open = $offset + \strlen( $open_match[0] );
 
-		if ( preg_match( $pattern, $html, $match, PREG_OFFSET_CAPTURE, $after_open ) ) {
-			$result = substr( $html, $offset, $match[0][1] - $offset );
-			return rtrim( $result );
+		if ( \preg_match( $pattern, $html, $match, \PREG_OFFSET_CAPTURE, $after_open ) ) {
+			$result = \substr( $html, $offset, $match[0][1] - $offset );
+			return \rtrim( $result );
 		}
 
-		return rtrim( substr( $html, $offset ) );
+		return \rtrim( \substr( $html, $offset ) );
 	}
 
 	/**
@@ -263,17 +263,17 @@ class TopLevelSplitter {
 	 * @return string
 	 */
 	private function extract_text( string $html, int $offset ): string {
-		$tags_pattern = implode( '|', self::BLOCK_TAGS );
+		$tags_pattern = \implode( '|', self::BLOCK_TAGS );
 		$stop_pattern = '/<(?:' . $tags_pattern . ')(?:\s[^>]*)?(?:\/>|>)|<!--(?:more|nextpage)-->|\[(\w[\w-]*)(?:\s[^\]]*)?]/i';
 
-		if ( preg_match( $stop_pattern, $html, $match, PREG_OFFSET_CAPTURE, $offset ) ) {
+		if ( \preg_match( $stop_pattern, $html, $match, \PREG_OFFSET_CAPTURE, $offset ) ) {
 			$stop_offset = $match[0][1];
 			if ( $stop_offset === $offset ) {
 				return '';
 			}
-			return rtrim( substr( $html, $offset, $stop_offset - $offset ) );
+			return \rtrim( \substr( $html, $offset, $stop_offset - $offset ) );
 		}
 
-		return rtrim( substr( $html, $offset ) );
+		return \rtrim( \substr( $html, $offset ) );
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -32,8 +32,8 @@ class Plugin {
 	 * @return void
 	 */
 	public static function init(): void {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			add_action(
+		if ( \defined( 'WP_CLI' ) && \WP_CLI ) {
+			\add_action(
 				'cli_init',
 				static function (): void {
 					$converter = self::create_content_converter();
@@ -44,7 +44,7 @@ class Plugin {
 			);
 		}
 
-		add_action(
+		\add_action(
 			'admin_init',
 			static function (): void {
 				$converter = self::create_content_converter();
@@ -85,7 +85,7 @@ class Plugin {
 		 *
 		 * @return \Apermo\ClassicToGutenberg\Converter\Shortcode\ShortcodeHandlerInterface[]
 		 */
-		$shortcode_handlers = apply_filters(
+		$shortcode_handlers = \apply_filters(
 			'classic_to_gutenberg_shortcode_handlers',
 			[
 				new CaptionHandler(),
@@ -103,7 +103,7 @@ class Plugin {
 		 *
 		 * @return BlockConverterFactory
 		 */
-		apply_filters( 'classic_to_gutenberg_converters', $factory );
+		\apply_filters( 'classic_to_gutenberg_converters', $factory );
 
 		return $factory;
 	}
@@ -117,7 +117,7 @@ class Plugin {
 		return new ContentConverter(
 			self::create_factory(),
 			new TopLevelSplitter(),
-			static fn( string $content ): string => wpautop( $content ),
+			static fn( string $content ): string => \wpautop( $content ),
 		);
 	}
 }

--- a/tests/Integration/ContentConverterTest.php
+++ b/tests/Integration/ContentConverterTest.php
@@ -21,6 +21,7 @@ use Apermo\ClassicToGutenberg\Converter\Shortcode\GalleryHandler;
 use Apermo\ClassicToGutenberg\Converter\ShortcodeConverter;
 use Apermo\ClassicToGutenberg\Converter\TableConverter;
 use Apermo\ClassicToGutenberg\Parser\TopLevelSplitter;
+use Generator;
 use WP_UnitTestCase;
 
 /**
@@ -42,29 +43,29 @@ class ContentConverterTest extends WP_UnitTestCase {
 	 *
 	 * @return \Generator<string, array{string, string}>
 	 */
-	public static function fixture_provider(): \Generator {
-		$fixtures_dir = dirname( __DIR__ ) . '/fixtures';
-		$inputs       = glob( $fixtures_dir . '/*.html' );
+	public static function fixture_provider(): Generator {
+		$fixtures_dir = \dirname( __DIR__ ) . '/fixtures';
+		$inputs       = \glob( $fixtures_dir . '/*.html' );
 
 		if ( $inputs === false ) {
 			return;
 		}
 
 		foreach ( $inputs as $input_file ) {
-			$basename = basename( $input_file, '.html' );
-			if ( str_ends_with( $basename, '.expected' ) ) {
+			$basename = \basename( $input_file, '.html' );
+			if ( \str_ends_with( $basename, '.expected' ) ) {
 				continue;
 			}
 
 			$expected_file = $fixtures_dir . '/' . $basename . '.expected.html';
-			if ( ! file_exists( $expected_file ) ) {
+			if ( ! \file_exists( $expected_file ) ) {
 				continue;
 			}
 
 			// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local fixtures
 			yield $basename => [
-				(string) file_get_contents( $input_file ),
-				trim( (string) file_get_contents( $expected_file ) ),
+				(string) \file_get_contents( $input_file ),
+				\trim( (string) \file_get_contents( $expected_file ) ),
 			];
 			// phpcs:enable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		}
@@ -101,7 +102,7 @@ class ContentConverterTest extends WP_UnitTestCase {
 		$this->converter = new ContentConverter(
 			$factory,
 			new TopLevelSplitter(),
-			static fn( string $content ): string => wpautop( $content ),
+			static fn( string $content ): string => \wpautop( $content ),
 		);
 	}
 

--- a/tests/Integration/ExampleIntegrationTest.php
+++ b/tests/Integration/ExampleIntegrationTest.php
@@ -17,7 +17,7 @@ class ExampleIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_wordpress_is_loaded(): void {
-		$this->assertTrue( function_exists( 'do_action' ) );
+		$this->assertTrue( \function_exists( 'do_action' ) );
 	}
 
 	/**
@@ -26,16 +26,16 @@ class ExampleIntegrationTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_project_is_active(): void {
-		$plugin_file = dirname( __DIR__, 2 ) . '/plugin.php';
+		$plugin_file = \dirname( __DIR__, 2 ) . '/plugin.php';
 
-		if ( file_exists( $plugin_file ) ) {
+		if ( \file_exists( $plugin_file ) ) {
 			$this->assertTrue(
-				defined( 'CLASSIC_TO_GUTENBERG_VERSION' ),
+				\defined( 'CLASSIC_TO_GUTENBERG_VERSION' ),
 				'Plugin constant CLASSIC_TO_GUTENBERG_VERSION should be defined.',
 			);
 		} else {
 			$this->assertNotFalse(
-				wp_get_theme()->get( 'Name' ),
+				\wp_get_theme()->get( 'Name' ),
 				'Active theme should have a name.',
 			);
 		}

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -18,7 +18,7 @@ class PluginTest extends TestCase {
 	 * @return void
 	 */
 	public function test_init_method_exists(): void {
-		$this->assertTrue( method_exists( Plugin::class, 'init' ) );
+		$this->assertTrue( \method_exists( Plugin::class, 'init' ) );
 	}
 
 	/**
@@ -27,6 +27,6 @@ class PluginTest extends TestCase {
 	 * @return void
 	 */
 	public function test_create_factory_method_exists(): void {
-		$this->assertTrue( method_exists( Plugin::class, 'create_factory' ) );
+		$this->assertTrue( \method_exists( Plugin::class, 'create_factory' ) );
 	}
 }


### PR DESCRIPTION
## Summary

- Upgrade `apermo/apermo-coding-standards` to 2.6.0 — fully qualify global functions and constants in namespaced code (auto-fixed via phpcbf)
- Add GitHub issue templates (bug report, feature request) and PR template
- Add Gemini AI code review config with project-specific styleguide

Skipped from template: `setup.sh`, theme-mode files, wporg-deploy workflow, renovate config.

## Version

This is a **0.1.1** patch — no functional changes, only tooling/infrastructure.

## Test plan

- [ ] PHPCS passes with new coding standards
- [ ] PHPStan passes
- [ ] Unit tests pass
- [ ] Integration tests pass (fully qualified function calls don't affect WP behavior)
- [ ] E2E smoke tests pass