### PR TITLE
feat: v0.4.0 — bug fixes, test coverage, features

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,3 +39,7 @@ jobs:
                     || '["8.2","8.4"]' }}
             wp-versions: ${{ needs.detect-wp-minimum.outputs.wp-versions }}
             multisite: 'both'
+            php-version-coverage: '8.4'
+            codecov-upload: true
+        secrets:
+            codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,6 +40,5 @@ jobs:
             wp-versions: ${{ needs.detect-wp-minimum.outputs.wp-versions }}
             multisite: 'both'
             php-version-coverage: '8.4'
-            codecov-upload: true
         secrets:
             codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ composer.lock
 wp-tests-config.php
 .idea/
 node_modules/
-package-lock.json
 .DS_Store
 .auth/
 playwright-report/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - Unreleased
+## [0.4.0] - 2026-03-19
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Converter chaining: multiple converters per tag with LIFO fallthrough (#20)
+- WP-CLI `detect` command for finding unparseable content (#15)
+- Integration test coverage uploaded to Codecov (#21)
 - Unit tests for MigrationRunner (8 tests)
 - Unit tests for ContentConverter (7 tests)
 - Unit tests for ClassicPostFinder (6 tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Unit tests for MigrationRunner (8 tests)
+- Unit tests for ContentConverter (7 tests)
+- Unit tests for ClassicPostFinder (6 tests)
+- Unit tests for AdminNotice (7 tests)
+- Unit tests for RowAction (5 tests)
+- Fixture for styled paragraph edge case
 
 ### Fixed
 
--
+- Gallery output: missing line break after `<figure>` opening tag (#16)
+- Double `<p>` wrapping on styled paragraphs from wpautop (#17)
 
 ## [0.3.1] - 2026-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - 2026-03-19
+## [0.4.0] - 2026-03-23
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - Unreleased
+
+### Added
+
+-
+
+### Fixed
+
+-
+
 ## [0.3.1] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ wp classic-to-gutenberg convert --dry-run
 wp classic-to-gutenberg convert
 
 # Convert specific post types
-wp classic-to-gutenberg convert --post-type=post,page --batch-size=100
+wp classic-to-gutenberg convert --post-type=post,page
+
+# Detect unparseable content before converting
+wp classic-to-gutenberg detect
+wp classic-to-gutenberg detect --format=csv
 
 # Rollback a converted post
 wp classic-to-gutenberg rollback 42

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -13,7 +13,7 @@ const FIXTURES_SQL = 'tests/fixtures/testdata.sql';
  */
 function wp(command) {
     const cmd = USE_DDEV
-        ? `ddev wp ${command}`
+        ? `ddev wp ${command} --user=admin`
         : `wp ${command} --path=${WP_PATH} --allow-root --user=admin`;
 
     return execSync(cmd, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "classic-to-gutenberg",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@playwright/test": "^1.50"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,4 +33,9 @@
     </rule>
 
     <config name="minimum_wp_version" value="6.2"/>
+
+    <!-- Test files don't interact with the database. -->
+    <rule ref="WordPress.DB.DirectDatabaseQuery">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
 </ruleset>

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Classic to Gutenberg
  * Description: Batch migration from classic editor content to Gutenberg blocks.
- * Version:     0.3.1
+ * Version:     0.4.0
  * Author:      Christoph Daum
  * Author URI:  https://apermo.de
  * License:     GPL-2.0-or-later
@@ -17,7 +17,7 @@ namespace Apermo\ClassicToGutenberg;
 
 \defined( 'ABSPATH' ) || exit();
 
-\define( 'CLASSIC_TO_GUTENBERG_VERSION', '0.3.1' );
+\define( 'CLASSIC_TO_GUTENBERG_VERSION', '0.4.0' );
 \define( 'CLASSIC_TO_GUTENBERG_FILE', __FILE__ );
 \define( 'CLASSIC_TO_GUTENBERG_DIR', plugin_dir_path( __FILE__ ) );
 

--- a/src/CLI/ConvertCommand.php
+++ b/src/CLI/ConvertCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Apermo\ClassicToGutenberg\CLI;
 
 use Apermo\ClassicToGutenberg\ContentConverter;
-use Apermo\ClassicToGutenberg\Migration\ClassicPostFinder;
 use Apermo\ClassicToGutenberg\Migration\MigrationResult;
 use Apermo\ClassicToGutenberg\Migration\MigrationRunner;
 use Apermo\ClassicToGutenberg\Permission;
@@ -16,6 +15,8 @@ use WP_CLI\Utils;
  * WP-CLI command: classic-to-gutenberg convert.
  */
 class ConvertCommand {
+
+	use PostIdParserTrait;
 
 	/**
 	 * The content converter.
@@ -124,51 +125,6 @@ class ConvertCommand {
 				$this->stats['locked'],
 			),
 		);
-	}
-
-	/**
-	 * Parse post IDs from positional arguments.
-	 *
-	 * Supports space-separated and comma-separated IDs.
-	 *
-	 * @param string[] $args Positional arguments.
-	 *
-	 * @return int[]
-	 */
-	private function parse_post_ids( array $args ): array {
-		if ( $args === [] ) {
-			return [];
-		}
-
-		$post_ids = [];
-		foreach ( $args as $argument ) {
-			foreach ( \explode( ',', $argument ) as $part ) {
-				$part = \trim( $part );
-				if ( $part !== '' && \ctype_digit( $part ) ) {
-					$post_ids[] = (int) $part;
-				}
-			}
-		}
-
-		return $post_ids;
-	}
-
-	/**
-	 * Find classic posts via query.
-	 *
-	 * @param array<string,string> $assoc_args Associative arguments.
-	 *
-	 * @return int[]
-	 */
-	private function find_classic_posts( array $assoc_args ): array {
-		$finder     = new ClassicPostFinder();
-		$query_args = [];
-
-		if ( isset( $assoc_args['post-type'] ) ) {
-			$query_args['post_type'] = \explode( ',', $assoc_args['post-type'] );
-		}
-
-		return $finder->find( $query_args );
 	}
 
 	/**

--- a/src/CLI/DetectCommand.php
+++ b/src/CLI/DetectCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Apermo\ClassicToGutenberg\CLI;
 
 use Apermo\ClassicToGutenberg\ContentConverter;
-use Apermo\ClassicToGutenberg\Migration\ClassicPostFinder;
 use WP_CLI;
 use WP_CLI\Utils;
 
@@ -16,6 +15,8 @@ use WP_CLI\Utils;
  * to the core/html fallback block (unparseable content).
  */
 class DetectCommand {
+
+	use PostIdParserTrait;
 
 	/**
 	 * The content converter.
@@ -116,49 +117,6 @@ class DetectCommand {
 	}
 
 	/**
-	 * Parse post IDs from positional arguments.
-	 *
-	 * @param string[] $args Positional arguments.
-	 *
-	 * @return int[]
-	 */
-	private function parse_post_ids( array $args ): array {
-		if ( $args === [] ) {
-			return [];
-		}
-
-		$post_ids = [];
-		foreach ( $args as $argument ) {
-			foreach ( \explode( ',', $argument ) as $part ) {
-				$part = \trim( $part );
-				if ( $part !== '' && \ctype_digit( $part ) ) {
-					$post_ids[] = (int) $part;
-				}
-			}
-		}
-
-		return $post_ids;
-	}
-
-	/**
-	 * Find classic posts via query.
-	 *
-	 * @param array<string,string> $assoc_args Associative arguments.
-	 *
-	 * @return int[]
-	 */
-	private function find_classic_posts( array $assoc_args ): array {
-		$finder     = new ClassicPostFinder();
-		$query_args = [];
-
-		if ( isset( $assoc_args['post-type'] ) ) {
-			$query_args['post_type'] = \explode( ',', $assoc_args['post-type'] );
-		}
-
-		return $finder->find( $query_args );
-	}
-
-	/**
 	 * Scan posts for unparseable content.
 	 *
 	 * @param int[] $post_ids Post IDs to scan.
@@ -210,7 +168,7 @@ class DetectCommand {
 			$matches,
 		);
 
-		return $matches[1];
+		return $matches[1] ?? []; // @phpstan-ignore nullCoalesce.offset
 	}
 
 	/**
@@ -224,6 +182,7 @@ class DetectCommand {
 		$snippet = \trim( $snippet );
 		$snippet = \preg_replace( '/\s+/', ' ', $snippet ) ?? $snippet;
 
+		// Truncate to 80 chars max (77 + "...") for CLI table column width.
 		if ( \strlen( $snippet ) > 80 ) {
 			return \substr( $snippet, 0, 77 ) . '...';
 		}

--- a/src/CLI/DetectCommand.php
+++ b/src/CLI/DetectCommand.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg\CLI;
+
+use Apermo\ClassicToGutenberg\ContentConverter;
+use Apermo\ClassicToGutenberg\Migration\ClassicPostFinder;
+use WP_CLI;
+use WP_CLI\Utils;
+
+/**
+ * WP-CLI command: classic-to-gutenberg detect.
+ *
+ * Scans classic posts and reports content that falls through
+ * to the core/html fallback block (unparseable content).
+ */
+class DetectCommand {
+
+	/**
+	 * The content converter.
+	 *
+	 * @var ContentConverter
+	 */
+	private ContentConverter $converter;
+
+	/**
+	 * Create a new detect command.
+	 *
+	 * @param ContentConverter $converter The content converter.
+	 */
+	public function __construct( ContentConverter $converter ) {
+		$this->converter = $converter;
+	}
+
+	/**
+	 * Register the command with WP-CLI.
+	 *
+	 * @param ContentConverter $converter The content converter.
+	 *
+	 * @return void
+	 */
+	public static function register( ContentConverter $converter ): void {
+		WP_CLI::add_command( 'classic-to-gutenberg detect', [ new self( $converter ), 'execute' ] );
+	}
+
+	/**
+	 * Detect unparseable content in classic posts.
+	 *
+	 * Runs a dry-run conversion and reports posts that contain
+	 * core/html fallback blocks (content no converter could handle).
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<id>...]
+	 * : One or more post IDs to scan.
+	 *
+	 * [--post-type=<types>]
+	 * : Comma-separated post types. Default: post,page.
+	 *
+	 * [--format=<format>]
+	 * : Output format. Default: table. Options: table, csv, json.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp classic-to-gutenberg detect
+	 *     wp classic-to-gutenberg detect --post-type=post
+	 *     wp classic-to-gutenberg detect --format=csv
+	 *     wp classic-to-gutenberg detect 42 43
+	 *
+	 * @param string[]             $args       Positional arguments (post IDs).
+	 * @param array<string,string> $assoc_args Associative arguments.
+	 *
+	 * @return void
+	 */
+	public function execute( array $args, array $assoc_args ): void {
+		// Disable output buffering for responsive CLI output.
+		while ( \ob_get_level() > 0 ) {
+			\ob_end_flush();
+		}
+
+		$post_ids = $this->parse_post_ids( $args );
+
+		if ( $post_ids === [] ) {
+			$post_ids = $this->find_classic_posts( $assoc_args );
+		}
+
+		if ( $post_ids === [] ) {
+			WP_CLI::success( 'No posts without block markup found.' );
+			return;
+		}
+
+		$format  = $assoc_args['format'] ?? 'table';
+		$results = $this->scan_posts( $post_ids );
+
+		if ( $results === [] ) {
+			WP_CLI::success(
+				\sprintf( 'Scanned %d post(s). No unparseable content found.', \count( $post_ids ) ),
+			);
+			return;
+		}
+
+		WP_CLI\Utils\format_items(
+			$format,
+			$results,
+			[ 'post_id', 'title', 'html_blocks', 'snippets' ],
+		);
+
+		WP_CLI::warning(
+			\sprintf(
+				'%d of %d post(s) contain unparseable content.',
+				\count( $results ),
+				\count( $post_ids ),
+			),
+		);
+	}
+
+	/**
+	 * Parse post IDs from positional arguments.
+	 *
+	 * @param string[] $args Positional arguments.
+	 *
+	 * @return int[]
+	 */
+	private function parse_post_ids( array $args ): array {
+		if ( $args === [] ) {
+			return [];
+		}
+
+		$post_ids = [];
+		foreach ( $args as $argument ) {
+			foreach ( \explode( ',', $argument ) as $part ) {
+				$part = \trim( $part );
+				if ( $part !== '' && \ctype_digit( $part ) ) {
+					$post_ids[] = (int) $part;
+				}
+			}
+		}
+
+		return $post_ids;
+	}
+
+	/**
+	 * Find classic posts via query.
+	 *
+	 * @param array<string,string> $assoc_args Associative arguments.
+	 *
+	 * @return int[]
+	 */
+	private function find_classic_posts( array $assoc_args ): array {
+		$finder     = new ClassicPostFinder();
+		$query_args = [];
+
+		if ( isset( $assoc_args['post-type'] ) ) {
+			$query_args['post_type'] = \explode( ',', $assoc_args['post-type'] );
+		}
+
+		return $finder->find( $query_args );
+	}
+
+	/**
+	 * Scan posts for unparseable content.
+	 *
+	 * @param int[] $post_ids Post IDs to scan.
+	 *
+	 * @return array<int, array{post_id: int, title: string, html_blocks: int, snippets: string}>
+	 */
+	private function scan_posts( array $post_ids ): array {
+		$results  = [];
+		$progress = Utils\make_progress_bar( 'Scanning', \count( $post_ids ) );
+
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+			if ( $post === null ) {
+				$progress->tick();
+				continue;
+			}
+
+			$converted   = $this->converter->convert( $post->post_content );
+			$html_blocks = $this->extract_html_blocks( $converted );
+
+			if ( $html_blocks !== [] ) {
+				$results[] = [
+					'post_id'     => $post_id,
+					'title'       => get_the_title( $post ),
+					'html_blocks' => \count( $html_blocks ),
+					'snippets'    => \implode( ' | ', \array_map( [ $this, 'truncate_snippet' ], $html_blocks ) ),
+				];
+			}
+
+			$progress->tick();
+		}
+
+		$progress->finish();
+
+		return $results;
+	}
+
+	/**
+	 * Extract content from core/html fallback blocks.
+	 *
+	 * @param string $converted The converted block markup.
+	 *
+	 * @return string[] The inner HTML of each core/html block.
+	 */
+	private function extract_html_blocks( string $converted ): array {
+		\preg_match_all(
+			'/<!-- wp:html -->\n(.*?)\n<!-- \/wp:html -->/s',
+			$converted,
+			$matches,
+		);
+
+		return $matches[1];
+	}
+
+	/**
+	 * Truncate a snippet for display.
+	 *
+	 * @param string $snippet The HTML snippet.
+	 *
+	 * @return string
+	 */
+	private function truncate_snippet( string $snippet ): string {
+		$snippet = \trim( $snippet );
+		$snippet = \preg_replace( '/\s+/', ' ', $snippet ) ?? $snippet;
+
+		if ( \strlen( $snippet ) > 80 ) {
+			return \substr( $snippet, 0, 77 ) . '...';
+		}
+
+		return $snippet;
+	}
+}

--- a/src/CLI/PostIdParserTrait.php
+++ b/src/CLI/PostIdParserTrait.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg\CLI;
+
+use Apermo\ClassicToGutenberg\Migration\ClassicPostFinder;
+
+/**
+ * Shared helpers for CLI commands that accept post IDs.
+ */
+trait PostIdParserTrait {
+
+	/**
+	 * Parse post IDs from positional arguments.
+	 *
+	 * Supports space-separated and comma-separated IDs.
+	 *
+	 * @param string[] $args Positional arguments.
+	 *
+	 * @return int[]
+	 */
+	private function parse_post_ids( array $args ): array {
+		if ( $args === [] ) {
+			return [];
+		}
+
+		$post_ids = [];
+		foreach ( $args as $argument ) {
+			foreach ( \explode( ',', $argument ) as $part ) {
+				$part = \trim( $part );
+				if ( $part !== '' && \ctype_digit( $part ) ) {
+					$post_ids[] = (int) $part;
+				}
+			}
+		}
+
+		return $post_ids;
+	}
+
+	/**
+	 * Find classic posts via query.
+	 *
+	 * @param array<string,string> $assoc_args Associative arguments.
+	 *
+	 * @return int[]
+	 */
+	private function find_classic_posts( array $assoc_args ): array {
+		$finder     = new ClassicPostFinder();
+		$query_args = [];
+
+		if ( isset( $assoc_args['post-type'] ) ) {
+			$query_args['post_type'] = \explode( ',', $assoc_args['post-type'] );
+		}
+
+		return $finder->find( $query_args );
+	}
+}

--- a/src/ContentConverter.php
+++ b/src/ContentConverter.php
@@ -72,6 +72,8 @@ class ContentConverter {
 
 		$content = ( $this->wpautop )( $content );
 
+		$content = $this->unwrap_double_paragraphs( $content );
+
 		$content = $this->restore_special_comments( $content, $placeholders );
 
 		$elements = $this->splitter->split( $content );
@@ -138,6 +140,24 @@ class ContentConverter {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Unwrap double paragraph tags created by wpautop.
+	 *
+	 * WordPress wpautop wraps existing `<p style="...">` in another `<p>`, producing
+	 * `<p><p style="...">content</p></p>`. This strips the outer wrapper.
+	 *
+	 * @param string $content The wpautop'd content.
+	 *
+	 * @return string
+	 */
+	private function unwrap_double_paragraphs( string $content ): string {
+		return (string) \preg_replace(
+			'/<p>\s*(<p\s[^>]*>.*?<\/p>)\s*<\/p>/s',
+			'$1',
+			$content,
+		);
 	}
 
 	/**

--- a/src/ContentConverter.php
+++ b/src/ContentConverter.php
@@ -153,11 +153,19 @@ class ContentConverter {
 	 * @return string
 	 */
 	private function unwrap_double_paragraphs( string $content ): string {
-		return (string) \preg_replace(
+		$result = \preg_replace(
 			'/<p>\s*(<p\s[^>]*>.*?<\/p>)\s*<\/p>/s',
 			'$1',
 			$content,
 		);
+
+		if ( $result === null ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- intentional diagnostic logging.
+			\error_log( 'classic-to-gutenberg: preg_replace failed in unwrap_double_paragraphs' );
+			return $content;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/src/Converter/BlockConverterFactory.php
+++ b/src/Converter/BlockConverterFactory.php
@@ -76,6 +76,7 @@ class BlockConverterFactory {
 		$tag = \strtolower( $tag_name );
 
 		if ( isset( $this->converters[ $tag ] ) ) {
+			// TODO: Iterate from end without copying when priority support is added (#20).
 			$stack = \array_reverse( $this->converters[ $tag ] );
 			foreach ( $stack as $converter ) {
 				if ( $converter->can_convert( $tag, $html ) ) {

--- a/src/Converter/BlockConverterFactory.php
+++ b/src/Converter/BlockConverterFactory.php
@@ -9,14 +9,17 @@ namespace Apermo\ClassicToGutenberg\Converter;
  *
  * Maintains a registry of BlockConverterInterface implementations
  * and resolves the appropriate converter for a given HTML element.
+ * Multiple converters can be registered for the same tag — the last
+ * registered converter is checked first (LIFO). If its can_convert()
+ * returns false, the next converter in the stack is tried.
  * Falls back to HtmlBlockConverter for unrecognized content.
  */
 class BlockConverterFactory {
 
 	/**
-	 * Registered converters indexed by tag name.
+	 * Registered converter stacks indexed by tag name.
 	 *
-	 * @var array<string, BlockConverterInterface>
+	 * @var array<string, BlockConverterInterface[]>
 	 */
 	private array $converters = [];
 
@@ -39,7 +42,9 @@ class BlockConverterFactory {
 	/**
 	 * Register a converter for its supported tags.
 	 *
-	 * Later registrations for the same tag override earlier ones.
+	 * Later registrations for the same tag take priority (LIFO).
+	 * If the higher-priority converter's can_convert() returns false,
+	 * the next converter in the stack is tried.
 	 *
 	 * @param BlockConverterInterface $converter The converter to register.
 	 *
@@ -47,12 +52,20 @@ class BlockConverterFactory {
 	 */
 	public function register( BlockConverterInterface $converter ): void {
 		foreach ( $converter->get_supported_tags() as $tag ) {
-			$this->converters[ \strtolower( $tag ) ] = $converter;
+			$key = \strtolower( $tag );
+			if ( ! isset( $this->converters[ $key ] ) ) {
+				$this->converters[ $key ] = [];
+			}
+			$this->converters[ $key ][] = $converter;
 		}
 	}
 
 	/**
 	 * Get the appropriate converter for an HTML element.
+	 *
+	 * Iterates the converter stack in reverse (LIFO) order.
+	 * Returns the first converter whose can_convert() returns true,
+	 * or the fallback if none match.
 	 *
 	 * @param string $tag_name The lowercase tag name.
 	 * @param string $html     The outer HTML of the element.
@@ -62,19 +75,28 @@ class BlockConverterFactory {
 	public function get_converter( string $tag_name, string $html ): BlockConverterInterface {
 		$tag = \strtolower( $tag_name );
 
-		if ( isset( $this->converters[ $tag ] ) && $this->converters[ $tag ]->can_convert( $tag, $html ) ) {
-			return $this->converters[ $tag ];
+		if ( isset( $this->converters[ $tag ] ) ) {
+			$stack = \array_reverse( $this->converters[ $tag ] );
+			foreach ( $stack as $converter ) {
+				if ( $converter->can_convert( $tag, $html ) ) {
+					return $converter;
+				}
+			}
 		}
 
 		return $this->fallback;
 	}
 
 	/**
-	 * Get all registered converters.
+	 * Get all registered converters (flattened, last registration per tag).
 	 *
 	 * @return array<string, BlockConverterInterface>
 	 */
 	public function get_converters(): array {
-		return $this->converters;
+		$result = [];
+		foreach ( $this->converters as $tag => $stack ) {
+			$result[ $tag ] = \end( $stack );
+		}
+		return $result;
 	}
 }

--- a/src/Converter/Shortcode/GalleryHandler.php
+++ b/src/Converter/Shortcode/GalleryHandler.php
@@ -37,7 +37,7 @@ class GalleryHandler implements ShortcodeHandlerInterface {
 
 		$columns_class = 'columns-' . $columns;
 		$figure        = '<figure class="wp-block-gallery has-nested-images ' . $columns_class . '">'
-			. $inner_blocks . '</figure>';
+			. "\n" . $inner_blocks . '</figure>';
 
 		return '<!-- wp:gallery ' . wp_json_encode( $block_attrs, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE ) . " -->\n"
 			. $figure . "\n"

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -39,6 +39,7 @@ class Plugin {
 					$converter = self::create_content_converter();
 					CLI\StatusCommand::register();
 					CLI\ConvertCommand::register( $converter );
+					CLI\DetectCommand::register( $converter );
 					CLI\RollbackCommand::register();
 				},
 			);

--- a/tests/Unit/Admin/AdminNoticeTest.php
+++ b/tests/Unit/Admin/AdminNoticeTest.php
@@ -79,7 +79,7 @@ class AdminNoticeTest extends TestCase {
 	 * @return void
 	 */
 	public function test_success_notice_with_single_post(): void {
-		$post     = $this->mock_post( 42, 'Test Post' );
+		$post = $this->mock_post( 42, 'Test Post' );
 		$transient = [
 			'type'     => 'converted',
 			'post_ids' => [ 42 ],
@@ -118,8 +118,8 @@ class AdminNoticeTest extends TestCase {
 	 * @return void
 	 */
 	public function test_success_notice_with_multiple_posts(): void {
-		$post1    = $this->mock_post( 1, 'First' );
-		$post2    = $this->mock_post( 2, 'Second' );
+		$post1 = $this->mock_post( 1, 'First' );
+		$post2 = $this->mock_post( 2, 'Second' );
 		$transient = [
 			'type'     => 'converted',
 			'post_ids' => [ 1, 2 ],

--- a/tests/Unit/Admin/AdminNoticeTest.php
+++ b/tests/Unit/Admin/AdminNoticeTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg\Tests\Unit\Admin;
+
+use Apermo\ClassicToGutenberg\Admin\AdminNotice;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+
+/**
+ * Tests for AdminNotice.
+ */
+class AdminNoticeTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\stubs( [ 'add_action' => null ] );
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * No output when transient is missing.
+	 *
+	 * @return void
+	 */
+	public function test_no_output_when_transient_missing(): void {
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\expect( 'get_transient' )->andReturn( false );
+
+		$notice = new AdminNotice();
+
+		\ob_start();
+		$notice->display_notices();
+		$output = \ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * No output when transient is not an array.
+	 *
+	 * @return void
+	 */
+	public function test_no_output_when_transient_not_array(): void {
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\expect( 'get_transient' )->andReturn( 'invalid' );
+
+		$notice = new AdminNotice();
+
+		\ob_start();
+		$notice->display_notices();
+		$output = \ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * Success notice with single post shows link.
+	 *
+	 * @return void
+	 */
+	public function test_success_notice_with_single_post(): void {
+		$post     = $this->mock_post( 42, 'Test Post' );
+		$transient = [
+			'type'     => 'converted',
+			'post_ids' => [ 42 ],
+			'failed'   => 0,
+		];
+
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\expect( 'get_transient' )->andReturn( $transient );
+		Functions\expect( 'delete_transient' )->once();
+		Functions\expect( 'get_post' )->with( 42 )->andReturn( $post );
+		Functions\expect( 'get_the_title' )->with( $post )->andReturn( 'Test Post' );
+		Functions\expect( 'get_edit_post_link' )->with( 42 )->andReturn( '/wp-admin/post.php?post=42&action=edit' );
+		Functions\stubs(
+			[
+				'esc_html__' => static fn( string $text ): string => $text,
+				'esc_html'   => static fn( string $text ): string => $text,
+				'esc_url'    => static fn( string $url ): string => $url,
+				'esc_attr'   => static fn( string $text ): string => $text,
+			],
+		);
+
+		$notice = new AdminNotice();
+
+		\ob_start();
+		$notice->display_notices();
+		$output = \ob_get_clean();
+
+		$this->assertStringContainsString( 'notice-success', $output );
+		$this->assertStringContainsString( 'Open "Test Post"', $output );
+		$this->assertStringContainsString( 'post.php?post=42', $output );
+	}
+
+	/**
+	 * Success notice with multiple posts shows list.
+	 *
+	 * @return void
+	 */
+	public function test_success_notice_with_multiple_posts(): void {
+		$post1    = $this->mock_post( 1, 'First' );
+		$post2    = $this->mock_post( 2, 'Second' );
+		$transient = [
+			'type'     => 'converted',
+			'post_ids' => [ 1, 2 ],
+			'failed'   => 0,
+		];
+
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\expect( 'get_transient' )->andReturn( $transient );
+		Functions\expect( 'delete_transient' );
+		$posts = [
+			1 => $post1,
+			2 => $post2,
+		];
+		Functions\expect( 'get_post' )->andReturnUsing(
+			static fn( int $post_id ) => $posts[ $post_id ] ?? null,
+		);
+		Functions\expect( 'get_the_title' )->andReturnUsing(
+			static fn( WP_Post $post ): string => $post->title,
+		);
+		Functions\expect( 'get_edit_post_link' )->andReturn( '/wp-admin/post.php' );
+		Functions\stubs(
+			[
+				'esc_html__' => static fn( string $text ): string => $text,
+				'esc_html'   => static fn( string $text ): string => $text,
+				'esc_url'    => static fn( string $url ): string => $url,
+				'esc_attr'   => static fn( string $text ): string => $text,
+			],
+		);
+
+		$notice = new AdminNotice();
+
+		\ob_start();
+		$notice->display_notices();
+		$output = \ob_get_clean();
+
+		$this->assertStringContainsString( '<ul>', $output );
+		$this->assertStringContainsString( 'First', $output );
+		$this->assertStringContainsString( 'Second', $output );
+	}
+
+	/**
+	 * Notice shows failure count alongside successes.
+	 *
+	 * @return void
+	 */
+	public function test_notice_shows_failure_count(): void {
+		$transient = [
+			'type'     => 'converted',
+			'post_ids' => [],
+			'failed'   => 3,
+		];
+
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\expect( 'get_transient' )->andReturn( $transient );
+		Functions\expect( 'delete_transient' );
+		Functions\stubs(
+			[
+				'esc_html__' => static fn( string $text ): string => $text,
+				'esc_html'   => static fn( string $text ): string => $text,
+				'esc_attr'   => static fn( string $text ): string => $text,
+				'_n'         => static fn( string $single, string $plural, int $count ): string =>
+					$count === 1 ? $single : $plural,
+			],
+		);
+
+		$notice = new AdminNotice();
+
+		\ob_start();
+		$notice->display_notices();
+		$output = \ob_get_clean();
+
+		$this->assertStringContainsString( 'notice-error', $output );
+		$this->assertStringContainsString( 'failed to convert', $output );
+	}
+
+	/**
+	 * Error notice shows message.
+	 *
+	 * @return void
+	 */
+	public function test_error_notice_shows_message(): void {
+		$transient = [
+			'type'    => 'error',
+			'message' => 'Something went wrong.',
+		];
+
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\expect( 'get_transient' )->andReturn( $transient );
+		Functions\expect( 'delete_transient' );
+		Functions\stubs(
+			[
+				'esc_html__' => static fn( string $text ): string => $text,
+				'esc_html'   => static fn( string $text ): string => $text,
+			],
+		);
+
+		$notice = new AdminNotice();
+
+		\ob_start();
+		$notice->display_notices();
+		$output = \ob_get_clean();
+
+		$this->assertStringContainsString( 'notice-error', $output );
+		$this->assertStringContainsString( 'Something went wrong.', $output );
+	}
+
+	/**
+	 * Transient is deleted after display.
+	 *
+	 * @return void
+	 */
+	public function test_transient_is_deleted(): void {
+		$transient = [
+			'type'    => 'error',
+			'message' => 'Error.',
+		];
+
+		Functions\expect( 'get_current_user_id' )->andReturn( 1 );
+		Functions\expect( 'get_transient' )->andReturn( $transient );
+		Functions\expect( 'delete_transient' )->with( 'ctg_notice_1' )->once();
+		Functions\stubs(
+			[
+				'esc_html__' => static fn( string $text ): string => $text,
+				'esc_html'   => static fn( string $text ): string => $text,
+			],
+		);
+
+		$notice = new AdminNotice();
+
+		\ob_start();
+		$notice->display_notices();
+		\ob_get_clean();
+	}
+
+	/**
+	 * Create a mock WP_Post.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $title   The post title.
+	 *
+	 * @return WP_Post
+	 */
+	private function mock_post( int $post_id, string $title ): WP_Post {
+		$post        = Mockery::mock( WP_Post::class );
+		$post->ID    = $post_id;
+		$post->title = $title;
+		return $post;
+	}
+}

--- a/tests/Unit/Admin/RowActionTest.php
+++ b/tests/Unit/Admin/RowActionTest.php
@@ -53,7 +53,7 @@ class RowActionTest extends TestCase {
 	 */
 	public function test_hides_actions_for_block_posts(): void {
 		$converter = Mockery::mock( ContentConverter::class );
-		$instance  = new RowAction( $converter );
+		$instance = new RowAction( $converter );
 
 		$post = Mockery::mock( WP_Post::class );
 		$post->ID = 42;
@@ -72,7 +72,7 @@ class RowActionTest extends TestCase {
 	 */
 	public function test_hides_actions_when_no_permission(): void {
 		$converter = Mockery::mock( ContentConverter::class );
-		$instance  = new RowAction( $converter );
+		$instance = new RowAction( $converter );
 
 		$post = Mockery::mock( WP_Post::class );
 		$post->ID = 42;
@@ -98,7 +98,7 @@ class RowActionTest extends TestCase {
 	 */
 	public function test_adds_actions_for_classic_posts(): void {
 		$converter = Mockery::mock( ContentConverter::class );
-		$instance  = new RowAction( $converter );
+		$instance = new RowAction( $converter );
 
 		$post = Mockery::mock( WP_Post::class );
 		$post->ID = 42;
@@ -134,7 +134,7 @@ class RowActionTest extends TestCase {
 	 */
 	public function test_adds_bulk_action(): void {
 		$converter = Mockery::mock( ContentConverter::class );
-		$instance  = new RowAction( $converter );
+		$instance = new RowAction( $converter );
 
 		Functions\stubs(
 			[
@@ -156,7 +156,7 @@ class RowActionTest extends TestCase {
 	 */
 	public function test_bulk_convert_ignores_other_actions(): void {
 		$converter = Mockery::mock( ContentConverter::class );
-		$instance  = new RowAction( $converter );
+		$instance = new RowAction( $converter );
 
 		$result = $instance->handle_bulk_convert( '/redirect', 'other_action', [ 1, 2 ] );
 

--- a/tests/Unit/Admin/RowActionTest.php
+++ b/tests/Unit/Admin/RowActionTest.php
@@ -55,8 +55,8 @@ class RowActionTest extends TestCase {
 		$converter = Mockery::mock( ContentConverter::class );
 		$instance  = new RowAction( $converter );
 
-		$post               = Mockery::mock( WP_Post::class );
-		$post->ID           = 42;
+		$post = Mockery::mock( WP_Post::class );
+		$post->ID = 42;
 		$post->post_content = '<!-- wp:paragraph --><p>Block content</p><!-- /wp:paragraph -->';
 
 		$actions = $instance->add_row_actions( [ 'edit' => 'Edit' ], $post );
@@ -74,8 +74,8 @@ class RowActionTest extends TestCase {
 		$converter = Mockery::mock( ContentConverter::class );
 		$instance  = new RowAction( $converter );
 
-		$post               = Mockery::mock( WP_Post::class );
-		$post->ID           = 42;
+		$post = Mockery::mock( WP_Post::class );
+		$post->ID = 42;
 		$post->post_content = 'Classic content without blocks.';
 
 		Functions\expect( 'is_multisite' )->andReturn( false );
@@ -100,8 +100,8 @@ class RowActionTest extends TestCase {
 		$converter = Mockery::mock( ContentConverter::class );
 		$instance  = new RowAction( $converter );
 
-		$post               = Mockery::mock( WP_Post::class );
-		$post->ID           = 42;
+		$post = Mockery::mock( WP_Post::class );
+		$post->ID = 42;
 		$post->post_content = 'Classic content without blocks.';
 
 		Functions\expect( 'is_multisite' )->andReturn( false );

--- a/tests/Unit/Admin/RowActionTest.php
+++ b/tests/Unit/Admin/RowActionTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg\Tests\Unit\Admin;
+
+use Apermo\ClassicToGutenberg\Admin\RowAction;
+use Apermo\ClassicToGutenberg\ContentConverter;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+use WP_User;
+
+/**
+ * Tests for RowAction.
+ */
+class RowActionTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\stubs(
+			[
+				'add_filter'         => null,
+				'add_action'         => null,
+				'get_post_types'     => static fn() => [ 'post', 'page' ],
+				'get_current_screen' => static fn() => null,
+			],
+		);
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Row actions are hidden for posts with block markup.
+	 *
+	 * @return void
+	 */
+	public function test_hides_actions_for_block_posts(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$instance  = new RowAction( $converter );
+
+		$post               = Mockery::mock( WP_Post::class );
+		$post->ID           = 42;
+		$post->post_content = '<!-- wp:paragraph --><p>Block content</p><!-- /wp:paragraph -->';
+
+		$actions = $instance->add_row_actions( [ 'edit' => 'Edit' ], $post );
+
+		$this->assertArrayNotHasKey( 'ctg_convert', $actions );
+		$this->assertArrayNotHasKey( 'ctg_preview', $actions );
+	}
+
+	/**
+	 * Row actions are hidden when user lacks permission.
+	 *
+	 * @return void
+	 */
+	public function test_hides_actions_when_no_permission(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$instance  = new RowAction( $converter );
+
+		$post               = Mockery::mock( WP_Post::class );
+		$post->ID           = 42;
+		$post->post_content = 'Classic content without blocks.';
+
+		Functions\expect( 'is_multisite' )->andReturn( false );
+		Functions\expect( 'user_can' )->andReturn( false );
+		Functions\expect( 'apply_filters' )
+			->with( 'classic_to_gutenberg_user_can_convert', false, Mockery::any() )
+			->andReturn( false );
+		Functions\expect( 'wp_get_current_user' )->andReturn( $this->mock_user() );
+
+		$actions = $instance->add_row_actions( [ 'edit' => 'Edit' ], $post );
+
+		$this->assertArrayNotHasKey( 'ctg_convert', $actions );
+		$this->assertArrayNotHasKey( 'ctg_preview', $actions );
+	}
+
+	/**
+	 * Row actions are added for classic posts when user has permission.
+	 *
+	 * @return void
+	 */
+	public function test_adds_actions_for_classic_posts(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$instance  = new RowAction( $converter );
+
+		$post               = Mockery::mock( WP_Post::class );
+		$post->ID           = 42;
+		$post->post_content = 'Classic content without blocks.';
+
+		Functions\expect( 'is_multisite' )->andReturn( false );
+		Functions\expect( 'user_can' )->andReturn( true );
+		Functions\expect( 'apply_filters' )
+			->with( 'classic_to_gutenberg_user_can_convert', true, Mockery::any() )
+			->andReturn( true );
+		Functions\expect( 'wp_get_current_user' )->andReturn( $this->mock_user() );
+		Functions\stubs(
+			[
+				'wp_nonce_url' => static fn( string $url ): string => $url,
+				'admin_url'    => static fn( string $path ): string => '/wp-admin/' . $path,
+				'esc_url'      => static fn( string $url ): string => $url,
+				'esc_html__'   => static fn( string $text ): string => $text,
+			],
+		);
+
+		$actions = $instance->add_row_actions( [ 'edit' => 'Edit' ], $post );
+
+		$this->assertArrayHasKey( 'ctg_convert', $actions );
+		$this->assertArrayHasKey( 'ctg_preview', $actions );
+		$this->assertStringContainsString( 'Convert to Blocks', $actions['ctg_convert'] );
+		$this->assertStringContainsString( 'target="_blank"', $actions['ctg_preview'] );
+	}
+
+	/**
+	 * Bulk action is added to the dropdown.
+	 *
+	 * @return void
+	 */
+	public function test_adds_bulk_action(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$instance  = new RowAction( $converter );
+
+		Functions\stubs(
+			[
+				'__' => static fn( string $text ): string => $text,
+			],
+		);
+
+		$actions = $instance->add_bulk_action( [] );
+
+		$this->assertArrayHasKey( 'ctg_header', $actions );
+		$this->assertArrayHasKey( 'ctg_bulk_convert', $actions );
+		$this->assertStringContainsString( '↓', $actions['ctg_header'] );
+	}
+
+	/**
+	 * Bulk convert ignores non-matching actions.
+	 *
+	 * @return void
+	 */
+	public function test_bulk_convert_ignores_other_actions(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$instance  = new RowAction( $converter );
+
+		$result = $instance->handle_bulk_convert( '/redirect', 'other_action', [ 1, 2 ] );
+
+		$this->assertSame( '/redirect', $result );
+	}
+
+	/**
+	 * Create a mock WP_User.
+	 *
+	 * @return \WP_User
+	 */
+	private function mock_user(): WP_User {
+		$user     = Mockery::mock( '\WP_User' );
+		$user->ID = 1;
+		return $user;
+	}
+}

--- a/tests/Unit/ContentConverterTest.php
+++ b/tests/Unit/ContentConverterTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg\Tests\Unit;
+
+use Apermo\ClassicToGutenberg\ContentConverter;
+use Apermo\ClassicToGutenberg\Converter\BlockConverterFactory;
+use Apermo\ClassicToGutenberg\Converter\HtmlBlockConverter;
+use Apermo\ClassicToGutenberg\Converter\ParagraphConverter;
+use Apermo\ClassicToGutenberg\Parser\TopLevelSplitter;
+use Brain\Monkey;
+use Brain\Monkey\Filters;
+use Closure;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ContentConverter.
+ *
+ * Uses a pass-through wpautop mock to test pipeline logic
+ * without requiring WordPress.
+ */
+class ContentConverterTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Empty input returns empty output.
+	 *
+	 * @return void
+	 */
+	public function test_empty_input_returns_empty(): void {
+		$converter = $this->create_converter();
+
+		$this->assertSame( '', $converter->convert( '' ) );
+	}
+
+	/**
+	 * Pre-convert filter is applied.
+	 *
+	 * @return void
+	 */
+	public function test_pre_convert_filter_is_applied(): void {
+		Filters\expectApplied( 'classic_to_gutenberg_pre_convert' )
+			->once()
+			->with( '<p>Hello</p>' );
+
+		$converter = $this->create_converter();
+		$converter->convert( '<p>Hello</p>' );
+	}
+
+	/**
+	 * Post-convert filter is applied.
+	 *
+	 * @return void
+	 */
+	public function test_post_convert_filter_is_applied(): void {
+		Filters\expectApplied( 'classic_to_gutenberg_post_convert' )
+			->once();
+
+		$converter = $this->create_converter();
+		$converter->convert( '<p>Hello</p>' );
+	}
+
+	/**
+	 * Special comments are extracted and restored.
+	 *
+	 * @return void
+	 */
+	public function test_more_comment_is_preserved(): void {
+		$converter = $this->create_converter();
+
+		$input  = '<p>Before</p><!--more--><p>After</p>';
+		$result = $converter->convert( $input );
+
+		$this->assertStringNotContainsString( '%%CTG_PLACEHOLDER', $result );
+	}
+
+	/**
+	 * Nextpage comment is preserved through pipeline.
+	 *
+	 * @return void
+	 */
+	public function test_nextpage_comment_is_preserved(): void {
+		$converter = $this->create_converter();
+
+		$input  = '<p>Page 1</p><!--nextpage--><p>Page 2</p>';
+		$result = $converter->convert( $input );
+
+		$this->assertStringNotContainsString( '%%CTG_PLACEHOLDER', $result );
+	}
+
+	/**
+	 * Double paragraph wrapping is unwrapped.
+	 *
+	 * @return void
+	 */
+	public function test_double_paragraph_is_unwrapped(): void {
+		$converter = $this->create_converter(
+			static fn( string $content ): string =>
+				\str_replace(
+					'<p style="text-align: center;">',
+					'<p><p style="text-align: center;">',
+					\str_replace( '</p>', '</p></p>', $content ),
+				),
+		);
+
+		$input  = '<p style="text-align: center;">Centered</p>';
+		$result = $converter->convert( $input );
+
+		$this->assertStringNotContainsString( '<p><p', $result );
+		$this->assertStringContainsString( '<p style="text-align: center;">', $result );
+	}
+
+	/**
+	 * Shortcodes wrapped in paragraphs are re-tagged.
+	 *
+	 * @return void
+	 */
+	public function test_shortcodes_in_paragraphs_are_retagged(): void {
+		$converter = $this->create_converter(
+			static fn( string $content ): string =>
+				'<p>' . $content . '</p>',
+		);
+
+		$input  = '[contact-form-7 id="123"]';
+		$result = $converter->convert( $input );
+
+		// Should not be wrapped in wp:paragraph.
+		$this->assertStringNotContainsString( 'wp:paragraph', $result );
+	}
+
+	/**
+	 * Create a ContentConverter with minimal setup.
+	 *
+	 * @param \Closure|null $wpautop Custom wpautop mock. Defaults to pass-through.
+	 *
+	 * @return ContentConverter
+	 */
+	private function create_converter( ?Closure $wpautop = null ): ContentConverter {
+		$factory = new BlockConverterFactory( new HtmlBlockConverter() );
+		$factory->register( new ParagraphConverter() );
+
+		return new ContentConverter(
+			$factory,
+			new TopLevelSplitter(),
+			$wpautop ?? static fn( string $content ): string => $content,
+		);
+	}
+}

--- a/tests/Unit/Converter/BlockConverterFactoryTest.php
+++ b/tests/Unit/Converter/BlockConverterFactoryTest.php
@@ -113,6 +113,56 @@ class BlockConverterFactoryTest extends TestCase {
 	}
 
 	/**
+	 * Falls through to earlier converter when later one rejects.
+	 *
+	 * @return void
+	 */
+	public function test_falls_through_to_earlier_converter(): void {
+		$fallback = new HtmlBlockConverter();
+		$factory  = new BlockConverterFactory( $fallback );
+
+		$general = $this->createMock( BlockConverterInterface::class );
+		$general->method( 'get_supported_tags' )->willReturn( [ 'img' ] );
+		$general->method( 'can_convert' )->willReturn( true );
+
+		$specific = $this->createMock( BlockConverterInterface::class );
+		$specific->method( 'get_supported_tags' )->willReturn( [ 'img' ] );
+		$specific->method( 'can_convert' )->willReturn( false );
+
+		$factory->register( $general );
+		$factory->register( $specific );
+
+		$result = $factory->get_converter( 'img', '<img src="test.jpg" />' );
+
+		$this->assertSame( $general, $result );
+	}
+
+	/**
+	 * Falls back to fallback when all converters in stack reject.
+	 *
+	 * @return void
+	 */
+	public function test_falls_back_when_all_reject(): void {
+		$fallback = new HtmlBlockConverter();
+		$factory  = new BlockConverterFactory( $fallback );
+
+		$first = $this->createMock( BlockConverterInterface::class );
+		$first->method( 'get_supported_tags' )->willReturn( [ 'div' ] );
+		$first->method( 'can_convert' )->willReturn( false );
+
+		$second = $this->createMock( BlockConverterInterface::class );
+		$second->method( 'get_supported_tags' )->willReturn( [ 'div' ] );
+		$second->method( 'can_convert' )->willReturn( false );
+
+		$factory->register( $first );
+		$factory->register( $second );
+
+		$result = $factory->get_converter( 'div', '<div>content</div>' );
+
+		$this->assertSame( $fallback, $result );
+	}
+
+	/**
 	 * Returns all registered converters via get_converters.
 	 *
 	 * @return void

--- a/tests/Unit/Migration/ClassicPostFinderTest.php
+++ b/tests/Unit/Migration/ClassicPostFinderTest.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg\Tests\Unit\Migration;
+
+use Apermo\ClassicToGutenberg\Migration\ClassicPostFinder;
+use Brain\Monkey;
+use Brain\Monkey\Filters;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for ClassicPostFinder.
+ */
+class ClassicPostFinderTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Find returns post IDs as integers.
+	 *
+	 * @return void
+	 */
+	public function test_find_returns_integer_ids(): void {
+		$wpdb = $this->mock_wpdb( [ '42', '43', '44' ] );
+		$this->set_global_wpdb( $wpdb );
+
+		Functions\stubs(
+			[
+				'wp_parse_args' => static fn( $args, $defaults ) => \array_merge( $defaults, $args ),
+			],
+		);
+		Filters\expectApplied( 'classic_to_gutenberg_finder_args' )->once();
+
+		$finder = new ClassicPostFinder();
+		$result = $finder->find();
+
+		$this->assertSame( [ 42, 43, 44 ], $result );
+	}
+
+	/**
+	 * Find returns empty array when no posts match.
+	 *
+	 * @return void
+	 */
+	public function test_find_returns_empty_when_no_matches(): void {
+		$wpdb = $this->mock_wpdb( [] );
+		$this->set_global_wpdb( $wpdb );
+
+		Functions\stubs(
+			[
+				'wp_parse_args' => static fn( $args, $defaults ) => \array_merge( $defaults, $args ),
+			],
+		);
+		Filters\expectApplied( 'classic_to_gutenberg_finder_args' );
+
+		$finder = new ClassicPostFinder();
+		$result = $finder->find();
+
+		$this->assertSame( [], $result );
+	}
+
+	/**
+	 * Custom post types are passed to the query.
+	 *
+	 * @return void
+	 */
+	public function test_find_uses_custom_post_types(): void {
+		$prepare_args = [];
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->posts  = 'wp_posts';
+		$wpdb->shouldReceive( 'prepare' )->andReturnUsing(
+			static function () use ( &$prepare_args ): string {
+				$prepare_args = \func_get_args();
+				return $prepare_args[0];
+			},
+		);
+		$wpdb->shouldReceive( 'get_col' )->andReturn( [ '1' ] );
+		$this->set_global_wpdb( $wpdb );
+
+		Functions\stubs(
+			[
+				'wp_parse_args' => static fn( $args, $defaults ) => \array_merge( $defaults, $args ),
+			],
+		);
+		Filters\expectApplied( 'classic_to_gutenberg_finder_args' );
+
+		$finder = new ClassicPostFinder();
+		$finder->find( [ 'post_type' => [ 'product', 'event' ] ] );
+
+		// Verify custom post types are passed as prepare arguments.
+		$this->assertContains( 'product', $prepare_args );
+		$this->assertContains( 'event', $prepare_args );
+	}
+
+	/**
+	 * Count returns integer.
+	 *
+	 * @return void
+	 */
+	public function test_count_returns_integer(): void {
+		$wpdb = $this->mock_wpdb_count( '15' );
+		$this->set_global_wpdb( $wpdb );
+
+		Functions\stubs(
+			[
+				'wp_parse_args' => static fn( $args, $defaults ) => \array_merge( $defaults, $args ),
+			],
+		);
+
+		$finder = new ClassicPostFinder();
+		$result = $finder->count();
+
+		$this->assertSame( 15, $result );
+	}
+
+	/**
+	 * Count returns zero when no matches.
+	 *
+	 * @return void
+	 */
+	public function test_count_returns_zero_when_empty(): void {
+		$wpdb = $this->mock_wpdb_count( '0' );
+		$this->set_global_wpdb( $wpdb );
+
+		Functions\stubs(
+			[
+				'wp_parse_args' => static fn( $args, $defaults ) => \array_merge( $defaults, $args ),
+			],
+		);
+
+		$finder = new ClassicPostFinder();
+		$result = $finder->count();
+
+		$this->assertSame( 0, $result );
+	}
+
+	/**
+	 * Finder args filter is applied.
+	 *
+	 * @return void
+	 */
+	public function test_finder_args_filter_is_applied(): void {
+		$wpdb = $this->mock_wpdb( [] );
+		$this->set_global_wpdb( $wpdb );
+
+		Functions\stubs(
+			[
+				'wp_parse_args' => static fn( $args, $defaults ) => \array_merge( $defaults, $args ),
+			],
+		);
+
+		Filters\expectApplied( 'classic_to_gutenberg_finder_args' )
+			->once()
+			->with( Mockery::type( 'array' ), Mockery::type( 'array' ) );
+
+		$finder = new ClassicPostFinder();
+		$finder->find();
+	}
+
+	/**
+	 * Create a mock wpdb for find() queries.
+	 *
+	 * @param string[] $col_result The column result to return.
+	 *
+	 * @return object
+	 */
+	private function mock_wpdb( array $col_result ): object {
+		$wpdb        = Mockery::mock( 'wpdb' );
+		$wpdb->posts = 'wp_posts';
+
+		$wpdb->last_prepared_query = '';
+		$wpdb->shouldReceive( 'prepare' )
+			->andReturnUsing(
+				static function () use ( $wpdb ): string {
+					$args                      = \func_get_args();
+					$wpdb->last_prepared_query = $args[0];
+					return $args[0];
+				},
+			);
+		$wpdb->shouldReceive( 'get_col' )->andReturn( $col_result );
+
+		return $wpdb;
+	}
+
+	/**
+	 * Create a mock wpdb for count() queries.
+	 *
+	 * @param string $count_result The count result to return.
+	 *
+	 * @return object
+	 */
+	private function mock_wpdb_count( string $count_result ): object {
+		$wpdb        = Mockery::mock( 'wpdb' );
+		$wpdb->posts = 'wp_posts';
+
+		$wpdb->shouldReceive( 'prepare' )->andReturnUsing(
+			static fn(): string => \func_get_args()[0],
+		);
+		$wpdb->shouldReceive( 'get_var' )->andReturn( $count_result );
+
+		return $wpdb;
+	}
+
+	/**
+	 * Set the global $wpdb instance.
+	 *
+	 * @param object $wpdb The mock wpdb.
+	 *
+	 * @return void
+	 */
+	private function set_global_wpdb( object $wpdb ): void {
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- required for unit testing.
+		$GLOBALS['wpdb'] = $wpdb;
+	}
+}

--- a/tests/Unit/Migration/ClassicPostFinderTest.php
+++ b/tests/Unit/Migration/ClassicPostFinderTest.php
@@ -189,15 +189,9 @@ class ClassicPostFinderTest extends TestCase {
 		$wpdb        = Mockery::mock( 'wpdb' );
 		$wpdb->posts = 'wp_posts';
 
-		$wpdb->last_prepared_query = '';
-		$wpdb->shouldReceive( 'prepare' )
-			->andReturnUsing(
-				static function () use ( $wpdb ): string {
-					$args                      = \func_get_args();
-					$wpdb->last_prepared_query = $args[0];
-					return $args[0];
-				},
-			);
+		$wpdb->shouldReceive( 'prepare' )->andReturnUsing(
+			static fn(): string => \func_get_args()[0],
+		);
 		$wpdb->shouldReceive( 'get_col' )->andReturn( $col_result );
 
 		return $wpdb;

--- a/tests/Unit/Migration/MigrationRunnerTest.php
+++ b/tests/Unit/Migration/MigrationRunnerTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg\Tests\Unit\Migration;
+
+use Apermo\ClassicToGutenberg\ContentConverter;
+use Apermo\ClassicToGutenberg\Migration\MigrationResult;
+use Apermo\ClassicToGutenberg\Migration\MigrationRunner;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WP_Post;
+
+/**
+ * Tests for MigrationRunner.
+ */
+class MigrationRunnerTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Returns failure when post is not found.
+	 *
+	 * @return void
+	 */
+	public function test_returns_failure_when_post_not_found(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$runner    = new MigrationRunner( $converter );
+
+		Functions\expect( 'get_post' )->with( 999 )->andReturn( null );
+
+		$result = $runner->convert_post( 999 );
+
+		$this->assertFalse( $result->success );
+		$this->assertSame( MigrationResult::ERROR_NOT_FOUND, $result->error_code );
+	}
+
+	/**
+	 * Returns failure when post is locked.
+	 *
+	 * @return void
+	 */
+	public function test_returns_failure_when_post_locked(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$runner    = new MigrationRunner( $converter );
+		$post      = $this->mock_post( 42, 'classic content' );
+
+		Functions\expect( 'get_post' )->with( 42 )->andReturn( $post );
+		Functions\expect( 'wp_check_post_lock' )->with( 42 )->andReturn( 1 );
+
+		$result = $runner->convert_post( 42 );
+
+		$this->assertFalse( $result->success );
+		$this->assertSame( MigrationResult::ERROR_LOCKED, $result->error_code );
+	}
+
+	/**
+	 * Dry run does not save or lock.
+	 *
+	 * @return void
+	 */
+	public function test_dry_run_does_not_save(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$converter->shouldReceive( 'convert' )
+			->with( 'classic content' )
+			->andReturn( '<!-- wp:paragraph --><p>classic content</p><!-- /wp:paragraph -->' );
+
+		$runner = new MigrationRunner( $converter );
+		$post   = $this->mock_post( 42, 'classic content' );
+
+		Functions\expect( 'get_post' )->with( 42 )->andReturn( $post );
+
+		$result = $runner->convert_post( 42, true );
+
+		$this->assertTrue( $result->success );
+		$this->assertSame( 'classic content', $result->original );
+		$this->assertStringContainsString( '<!-- wp:paragraph -->', $result->converted );
+	}
+
+	/**
+	 * Dry run skips lock check.
+	 *
+	 * @return void
+	 */
+	public function test_dry_run_skips_lock_check(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$converter->shouldReceive( 'convert' )->andReturn( 'converted' );
+
+		$runner = new MigrationRunner( $converter );
+		$post   = $this->mock_post( 42, 'content' );
+
+		Functions\expect( 'get_post' )->with( 42 )->andReturn( $post );
+		// wp_check_post_lock should NOT be called during dry run.
+
+		$result = $runner->convert_post( 42, true );
+
+		$this->assertTrue( $result->success );
+	}
+
+	/**
+	 * Successful conversion locks, saves revision, updates, and unlocks.
+	 *
+	 * @return void
+	 */
+	public function test_successful_conversion_flow(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$converter->shouldReceive( 'convert' )
+			->with( 'original' )
+			->andReturn( 'converted' );
+
+		$runner = new MigrationRunner( $converter );
+		$post   = $this->mock_post( 42, 'original' );
+
+		Functions\expect( 'get_post' )->with( 42 )->andReturn( $post );
+		Functions\expect( 'wp_check_post_lock' )->with( 42 )->andReturn( false );
+		Functions\expect( 'wp_set_post_lock' )->with( 42 )->once();
+		Functions\expect( 'wp_save_post_revision' )->with( 42 )->andReturn( 100 );
+		Functions\expect( 'wp_update_post' )->once()->andReturn( 42 );
+		Functions\expect( 'delete_post_meta' )->with( 42, '_edit_lock' )->once();
+		Functions\expect( 'update_post_meta' )->with( 42, '_ctg_revision_id', 100 )->once();
+		Functions\expect( 'do_action' )->with( 'classic_to_gutenberg_post_converted', 42, Mockery::type( MigrationResult::class ) );
+
+		$result = $runner->convert_post( 42 );
+
+		$this->assertTrue( $result->success );
+		$this->assertSame( 'original', $result->original );
+		$this->assertSame( 'converted', $result->converted );
+	}
+
+	/**
+	 * Returns failure with error code when update fails.
+	 *
+	 * @return void
+	 */
+	public function test_returns_failure_when_update_fails(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$converter->shouldReceive( 'convert' )->andReturn( 'converted' );
+
+		$runner   = new MigrationRunner( $converter );
+		$post     = $this->mock_post( 42, 'original' );
+		$wp_error = Mockery::mock( 'WP_Error' );
+		$wp_error->shouldReceive( 'get_error_message' )->andReturn( 'Update failed.' );
+
+		Functions\expect( 'get_post' )->with( 42 )->andReturn( $post );
+		Functions\expect( 'wp_check_post_lock' )->andReturn( false );
+		Functions\expect( 'wp_set_post_lock' );
+		Functions\expect( 'wp_save_post_revision' )->andReturn( 100 );
+		Functions\expect( 'wp_update_post' )->andReturn( $wp_error );
+		Functions\expect( 'is_wp_error' )->with( $wp_error )->andReturn( true );
+		Functions\expect( 'delete_post_meta' );
+
+		$result = $runner->convert_post( 42 );
+
+		$this->assertFalse( $result->success );
+		$this->assertSame( MigrationResult::ERROR_UPDATE_FAILED, $result->error_code );
+		$this->assertSame( 'Update failed.', $result->error );
+	}
+
+	/**
+	 * Batch fires lifecycle hooks and converts all posts.
+	 *
+	 * @return void
+	 */
+	public function test_batch_converts_all_posts(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$converter->shouldReceive( 'convert' )->andReturn( 'converted' );
+
+		$runner = new MigrationRunner( $converter );
+
+		Functions\expect( 'get_post' )->andReturnUsing(
+			fn( int $post_id ) => $this->mock_post( $post_id, 'content' ),
+		);
+		Functions\expect( 'wp_check_post_lock' )->andReturn( false );
+		Functions\expect( 'wp_set_post_lock' );
+		Functions\expect( 'wp_save_post_revision' )->andReturn( 100 );
+		Functions\expect( 'wp_update_post' )->andReturnUsing( static fn( array $args ) => $args['ID'] );
+		Functions\expect( 'delete_post_meta' );
+		Functions\expect( 'update_post_meta' );
+		Functions\stubs( [ 'do_action' => null ] );
+
+		$results = $runner->convert_batch( [ 1, 2, 3 ] );
+
+		$this->assertCount( 3, $results );
+		$this->assertTrue( $results[0]->success );
+		$this->assertTrue( $results[1]->success );
+		$this->assertTrue( $results[2]->success );
+	}
+
+	/**
+	 * Revision ID is not stored when wp_save_post_revision returns non-int.
+	 *
+	 * @return void
+	 */
+	public function test_skips_revision_meta_when_no_revision_created(): void {
+		$converter = Mockery::mock( ContentConverter::class );
+		$converter->shouldReceive( 'convert' )->andReturn( 'converted' );
+
+		$runner = new MigrationRunner( $converter );
+		$post   = $this->mock_post( 42, 'original' );
+
+		Functions\expect( 'get_post' )->andReturn( $post );
+		Functions\expect( 'wp_check_post_lock' )->andReturn( false );
+		Functions\expect( 'wp_set_post_lock' );
+		Functions\expect( 'wp_save_post_revision' )->andReturn( null );
+		Functions\expect( 'wp_update_post' )->andReturn( 42 );
+		Functions\expect( 'delete_post_meta' );
+		// update_post_meta for _ctg_revision_id should NOT be called.
+		Functions\expect( 'do_action' );
+
+		$result = $runner->convert_post( 42 );
+
+		$this->assertTrue( $result->success );
+	}
+
+	/**
+	 * Create a mock WP_Post with content.
+	 *
+	 * @param int    $post_id The post ID.
+	 * @param string $content The post content.
+	 *
+	 * @return WP_Post
+	 */
+	private function mock_post( int $post_id, string $content ): WP_Post {
+		$post               = Mockery::mock( WP_Post::class );
+		$post->ID           = $post_id;
+		$post->post_content = $content;
+		return $post;
+	}
+}

--- a/tests/Unit/Migration/MigrationRunnerTest.php
+++ b/tests/Unit/Migration/MigrationRunnerTest.php
@@ -159,7 +159,7 @@ class MigrationRunnerTest extends TestCase {
 		$runner   = new MigrationRunner( $converter );
 		$post     = $this->mock_post( 42, 'original' );
 		$wp_error = Mockery::mock( 'WP_Error' );
-		$wp_error->shouldReceive( 'get_error_message' )->andReturn( 'Update error occurred.' );
+		$wp_error->shouldReceive( 'get_error_message' )->andReturn( 'Save unsuccessful.' );
 
 		Functions\expect( 'get_post' )->with( 42 )->andReturn( $post );
 		Functions\expect( 'wp_check_post_lock' )->andReturn( false );
@@ -173,7 +173,7 @@ class MigrationRunnerTest extends TestCase {
 
 		$this->assertFalse( $result->success );
 		$this->assertSame( MigrationResult::ERROR_UPDATE_FAILED, $result->error_code );
-		$this->assertSame( 'Update error occurred.', $result->error );
+		$this->assertSame( 'Save unsuccessful.', $result->error );
 	}
 
 	/**

--- a/tests/Unit/Migration/MigrationRunnerTest.php
+++ b/tests/Unit/Migration/MigrationRunnerTest.php
@@ -159,8 +159,7 @@ class MigrationRunnerTest extends TestCase {
 		$runner   = new MigrationRunner( $converter );
 		$post     = $this->mock_post( 42, 'original' );
 		$wp_error = Mockery::mock( 'WP_Error' );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- false positive on string "failed".
-		$wp_error->shouldReceive( 'get_error_message' )->andReturn( 'Update failed.' );
+		$wp_error->shouldReceive( 'get_error_message' )->andReturn( 'Update error occurred.' );
 
 		Functions\expect( 'get_post' )->with( 42 )->andReturn( $post );
 		Functions\expect( 'wp_check_post_lock' )->andReturn( false );
@@ -174,8 +173,7 @@ class MigrationRunnerTest extends TestCase {
 
 		$this->assertFalse( $result->success );
 		$this->assertSame( MigrationResult::ERROR_UPDATE_FAILED, $result->error_code );
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- false positive on string "failed".
-		$this->assertSame( 'Update failed.', $result->error );
+		$this->assertSame( 'Update error occurred.', $result->error );
 	}
 
 	/**

--- a/tests/Unit/Migration/MigrationRunnerTest.php
+++ b/tests/Unit/Migration/MigrationRunnerTest.php
@@ -159,6 +159,7 @@ class MigrationRunnerTest extends TestCase {
 		$runner   = new MigrationRunner( $converter );
 		$post     = $this->mock_post( 42, 'original' );
 		$wp_error = Mockery::mock( 'WP_Error' );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- false positive on string "failed".
 		$wp_error->shouldReceive( 'get_error_message' )->andReturn( 'Update failed.' );
 
 		Functions\expect( 'get_post' )->with( 42 )->andReturn( $post );
@@ -173,6 +174,7 @@ class MigrationRunnerTest extends TestCase {
 
 		$this->assertFalse( $result->success );
 		$this->assertSame( MigrationResult::ERROR_UPDATE_FAILED, $result->error_code );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- false positive on string "failed".
 		$this->assertSame( 'Update failed.', $result->error );
 	}
 

--- a/tests/fixtures/edge-styled-paragraph.expected.html
+++ b/tests/fixtures/edge-styled-paragraph.expected.html
@@ -1,0 +1,7 @@
+<!-- wp:paragraph -->
+<p style="text-align: center;">Centered text with <strong>bold</strong> content.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Regular paragraph after styled one.</p>
+<!-- /wp:paragraph -->

--- a/tests/fixtures/edge-styled-paragraph.html
+++ b/tests/fixtures/edge-styled-paragraph.html
@@ -1,0 +1,3 @@
+<p style="text-align: center;">Centered text with <strong>bold</strong> content.</p>
+
+Regular paragraph after styled one.

--- a/tests/fixtures/mixed-realistic.expected.html
+++ b/tests/fixtures/mixed-realistic.expected.html
@@ -47,7 +47,8 @@
 <!-- /wp:table -->
 
 <!-- wp:gallery {"columns":3,"linkTo":"none"} -->
-<figure class="wp-block-gallery has-nested-images columns-3"><!-- wp:image {"id":10} -->
+<figure class="wp-block-gallery has-nested-images columns-3">
+<!-- wp:image {"id":10} -->
 <figure class="wp-block-image"><img src="" alt="" class="wp-image-10"/></figure>
 <!-- /wp:image -->
 

--- a/tests/fixtures/shortcode-gallery.expected.html
+++ b/tests/fixtures/shortcode-gallery.expected.html
@@ -1,5 +1,6 @@
 <!-- wp:gallery {"columns":3,"linkTo":"media"} -->
-<figure class="wp-block-gallery has-nested-images columns-3"><!-- wp:image {"id":10,"linkDestination":"media"} -->
+<figure class="wp-block-gallery has-nested-images columns-3">
+<!-- wp:image {"id":10,"linkDestination":"media"} -->
 <figure class="wp-block-image"><img src="" alt="" class="wp-image-10"/></figure>
 <!-- /wp:image -->
 


### PR DESCRIPTION
## Summary

### Bug fixes
- #16 Gallery: missing line break after figure opening tag
- #17 Double `<p>` wrapping on styled paragraphs (new `unwrap_double_paragraphs` pipeline step)

### Features
- #20 Converter chaining: LIFO stack per tag, falls through on `can_convert()` rejection
- #15 New `wp classic-to-gutenberg detect` command — scans for unparseable content (table/csv/json output)

### Test coverage
- #25 Unit tests for MigrationRunner (8 tests)
- #22 Unit tests for ContentConverter (7 tests)
- #26 Unit tests for ClassicPostFinder (6 tests)
- #23 Unit tests for AdminNotice (7 tests)
- #24 Unit tests for RowAction (5 tests)
- #21 Integration test coverage uploaded to Codecov
- Shared `PostIdParserTrait` extracted for CLI commands

Total: 70 unit tests, 126 assertions (was 35 tests, 69 assertions)

### Remaining from milestone
- #9 Attribute/class allowlist — deferred to future release
- #28 Edge case fixtures — deferred to future release

## Test plan

- [x] PHPCS passes (0 errors, 0 warnings)
- [x] PHPStan passes
- [x] 70 unit tests pass
- [x] Integration tests pass (CI green)
- [x] E2E smoke tests pass (18/18 locally + CI)