### PR TITLE
feat: converter extensibility interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-03-24
+
+### Added
+
+- `ContentConverterInterface` for addon plugins to provide custom conversion pipelines (#33)
+- `BlockMarkup` utility class with public `wrap()` and `self_closing()` helpers (#34)
+
+### Changed
+
+- `MigrationRunner` accepts `ContentConverterInterface` instead of concrete `ContentConverter`
+- `AbstractBlockConverter` delegates to `BlockMarkup` internally
+
 ## [0.4.0] - 2026-03-23
 
 ### Added

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Classic to Gutenberg
  * Description: Batch migration from classic editor content to Gutenberg blocks.
- * Version:     0.4.0
+ * Version:     0.5.0
  * Author:      Christoph Daum
  * Author URI:  https://apermo.de
  * License:     GPL-2.0-or-later
@@ -17,7 +17,7 @@ namespace Apermo\ClassicToGutenberg;
 
 \defined( 'ABSPATH' ) || exit();
 
-\define( 'CLASSIC_TO_GUTENBERG_VERSION', '0.4.0' );
+\define( 'CLASSIC_TO_GUTENBERG_VERSION', '0.5.0' );
 \define( 'CLASSIC_TO_GUTENBERG_FILE', __FILE__ );
 \define( 'CLASSIC_TO_GUTENBERG_DIR', plugin_dir_path( __FILE__ ) );
 

--- a/src/ContentConverter.php
+++ b/src/ContentConverter.php
@@ -12,7 +12,7 @@ use Closure;
 /**
  * Full content conversion pipeline: raw classic content to Gutenberg blocks.
  */
-class ContentConverter {
+class ContentConverter implements ContentConverterInterface {
 
 	/**
 	 * The block converter factory.

--- a/src/ContentConverterInterface.php
+++ b/src/ContentConverterInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg;
+
+/**
+ * Interface for content converters.
+ *
+ * Implementations convert classic editor content into Gutenberg block markup.
+ * Addon plugins can provide custom implementations (e.g. page builder converters)
+ * that pre-process content before delegating to the core pipeline.
+ *
+ * @since 0.5.0
+ */
+interface ContentConverterInterface {
+
+	/**
+	 * Convert classic editor content to Gutenberg block markup.
+	 *
+	 * @param string $content Raw classic editor content.
+	 *
+	 * @return string Gutenberg block markup.
+	 */
+	public function convert( string $content ): string;
+}

--- a/src/Converter/AbstractBlockConverter.php
+++ b/src/Converter/AbstractBlockConverter.php
@@ -31,9 +31,7 @@ abstract class AbstractBlockConverter implements BlockConverterInterface {
 	 * @return string
 	 */
 	protected function wrap_block( string $block_name, string $content, array $attrs = [] ): string {
-		$attrs_string = $attrs !== [] ? ' ' . wp_json_encode( $attrs, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE ) : '';
-
-		return "<!-- wp:{$block_name}{$attrs_string} -->\n{$content}\n<!-- /wp:{$block_name} -->";
+		return BlockMarkup::wrap( $block_name, $content, $attrs );
 	}
 
 	/**
@@ -45,8 +43,6 @@ abstract class AbstractBlockConverter implements BlockConverterInterface {
 	 * @return string
 	 */
 	protected function self_closing_block( string $block_name, array $attrs = [] ): string {
-		$attrs_string = $attrs !== [] ? ' ' . wp_json_encode( $attrs, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE ) : '';
-
-		return "<!-- wp:{$block_name}{$attrs_string} /-->";
+		return BlockMarkup::self_closing( $block_name, $attrs );
 	}
 }

--- a/src/Converter/BlockMarkup.php
+++ b/src/Converter/BlockMarkup.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg\Converter;
+
+/**
+ * Public utility for building Gutenberg block comment markup.
+ *
+ * Provides the same serialization logic used internally by AbstractBlockConverter,
+ * but accessible to addon plugins that build blocks outside of a BlockConverterInterface.
+ *
+ * @since 0.5.0
+ */
+final class BlockMarkup {
+
+	/**
+	 * Wrap content in a Gutenberg block comment delimiter.
+	 *
+	 * @param string               $block_name Block name without core/ prefix (e.g. 'paragraph').
+	 * @param string               $content    The inner HTML content.
+	 * @param array<string, mixed> $attrs      Block attributes.
+	 *
+	 * @return string
+	 */
+	public static function wrap( string $block_name, string $content, array $attrs = [] ): string {
+		$attrs_string = self::encode_attrs( $attrs );
+
+		return "<!-- wp:{$block_name}{$attrs_string} -->\n{$content}\n<!-- /wp:{$block_name} -->";
+	}
+
+	/**
+	 * Create a self-closing Gutenberg block.
+	 *
+	 * @param string               $block_name Block name without core/ prefix.
+	 * @param array<string, mixed> $attrs      Block attributes.
+	 *
+	 * @return string
+	 */
+	public static function self_closing( string $block_name, array $attrs = [] ): string {
+		$attrs_string = self::encode_attrs( $attrs );
+
+		return "<!-- wp:{$block_name}{$attrs_string} /-->";
+	}
+
+	/**
+	 * Encode block attributes to a JSON string for the comment delimiter.
+	 *
+	 * @param array<string, mixed> $attrs Block attributes.
+	 *
+	 * @return string Empty string or space-prefixed JSON.
+	 */
+	private static function encode_attrs( array $attrs ): string {
+		if ( $attrs === [] ) {
+			return '';
+		}
+
+		return ' ' . wp_json_encode( $attrs, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE );
+	}
+}

--- a/src/Converter/BlockMarkup.php
+++ b/src/Converter/BlockMarkup.php
@@ -17,7 +17,7 @@ final class BlockMarkup {
 	/**
 	 * Wrap content in a Gutenberg block comment delimiter.
 	 *
-	 * @param string               $block_name Block name without core/ prefix (e.g. 'paragraph').
+	 * @param string               $block_name Block name (e.g. 'paragraph' or 'my-plugin/my-block').
 	 * @param string               $content    The inner HTML content.
 	 * @param array<string, mixed> $attrs      Block attributes.
 	 *
@@ -32,7 +32,7 @@ final class BlockMarkup {
 	/**
 	 * Create a self-closing Gutenberg block.
 	 *
-	 * @param string               $block_name Block name without core/ prefix.
+	 * @param string               $block_name Block name (e.g. 'nextpage' or 'my-plugin/my-block').
 	 * @param array<string, mixed> $attrs      Block attributes.
 	 *
 	 * @return string

--- a/src/Migration/MigrationRunner.php
+++ b/src/Migration/MigrationRunner.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Apermo\ClassicToGutenberg\Migration;
 
-use Apermo\ClassicToGutenberg\ContentConverter;
+use Apermo\ClassicToGutenberg\ContentConverterInterface;
 
 /**
  * Runs the migration for individual posts or batches.
@@ -14,16 +14,16 @@ class MigrationRunner {
 	/**
 	 * The content converter.
 	 *
-	 * @var ContentConverter
+	 * @var ContentConverterInterface
 	 */
-	private ContentConverter $converter;
+	private ContentConverterInterface $converter;
 
 	/**
 	 * Create a new migration runner.
 	 *
-	 * @param ContentConverter $converter The content converter.
+	 * @param ContentConverterInterface $converter The content converter.
 	 */
-	public function __construct( ContentConverter $converter ) {
+	public function __construct( ContentConverterInterface $converter ) {
 		$this->converter = $converter;
 	}
 

--- a/tests/Unit/Converter/BlockMarkupTest.php
+++ b/tests/Unit/Converter/BlockMarkupTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apermo\ClassicToGutenberg\Tests\Unit\Converter;
+
+use Apermo\ClassicToGutenberg\Converter\BlockMarkup;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for BlockMarkup utility class.
+ */
+class BlockMarkupTest extends TestCase {
+
+	/**
+	 * Set up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		Functions\stubs(
+			[
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- test stub for wp_json_encode
+				'wp_json_encode' => static fn( $data, $flags = 0 ): string => (string) \json_encode( $data, $flags ),
+			],
+		);
+	}
+
+	/**
+	 * Tear down Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Wrap produces correct block markup without attributes.
+	 *
+	 * @return void
+	 */
+	public function test_wrap_without_attrs(): void {
+		$result = BlockMarkup::wrap( 'paragraph', '<p>Hello</p>' );
+
+		$this->assertSame(
+			"<!-- wp:paragraph -->\n<p>Hello</p>\n<!-- /wp:paragraph -->",
+			$result,
+		);
+	}
+
+	/**
+	 * Wrap produces correct block markup with attributes.
+	 *
+	 * @return void
+	 */
+	public function test_wrap_with_attrs(): void {
+		$result = BlockMarkup::wrap( 'column', '<div>Inner</div>', [ 'width' => '50%' ] );
+
+		$this->assertSame(
+			"<!-- wp:column {\"width\":\"50%\"} -->\n<div>Inner</div>\n<!-- /wp:column -->",
+			$result,
+		);
+	}
+
+	/**
+	 * Self-closing produces correct block markup without attributes.
+	 *
+	 * @return void
+	 */
+	public function test_self_closing_without_attrs(): void {
+		$result = BlockMarkup::self_closing( 'nextpage' );
+
+		$this->assertSame( '<!-- wp:nextpage /-->', $result );
+	}
+
+	/**
+	 * Self-closing produces correct block markup with attributes.
+	 *
+	 * @return void
+	 */
+	public function test_self_closing_with_attrs(): void {
+		$result = BlockMarkup::self_closing( 'spacer', [ 'height' => '32px' ] );
+
+		$this->assertSame( '<!-- wp:spacer {"height":"32px"} /-->', $result );
+	}
+
+	/**
+	 * Attributes with slashes and unicode are not escaped.
+	 *
+	 * @return void
+	 */
+	public function test_attrs_preserve_slashes_and_unicode(): void {
+		$result = BlockMarkup::wrap(
+			'image',
+			'<figure></figure>',
+			[
+				'url' => 'https://example.com/img.jpg',
+				'alt' => 'Ünïcödé',
+			],
+		);
+
+		$this->assertStringContainsString( 'https://example.com/img.jpg', $result );
+		$this->assertStringContainsString( 'Ünïcödé', $result );
+	}
+}

--- a/tests/Unit/Migration/MigrationRunnerTest.php
+++ b/tests/Unit/Migration/MigrationRunnerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Apermo\ClassicToGutenberg\Tests\Unit\Migration;
 
-use Apermo\ClassicToGutenberg\ContentConverter;
+use Apermo\ClassicToGutenberg\ContentConverterInterface;
 use Apermo\ClassicToGutenberg\Migration\MigrationResult;
 use Apermo\ClassicToGutenberg\Migration\MigrationRunner;
 use Brain\Monkey;
@@ -44,7 +44,7 @@ class MigrationRunnerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_returns_failure_when_post_not_found(): void {
-		$converter = Mockery::mock( ContentConverter::class );
+		$converter = Mockery::mock( ContentConverterInterface::class );
 		$runner    = new MigrationRunner( $converter );
 
 		Functions\expect( 'get_post' )->with( 999 )->andReturn( null );
@@ -61,7 +61,7 @@ class MigrationRunnerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_returns_failure_when_post_locked(): void {
-		$converter = Mockery::mock( ContentConverter::class );
+		$converter = Mockery::mock( ContentConverterInterface::class );
 		$runner    = new MigrationRunner( $converter );
 		$post      = $this->mock_post( 42, 'classic content' );
 
@@ -80,7 +80,7 @@ class MigrationRunnerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_dry_run_does_not_save(): void {
-		$converter = Mockery::mock( ContentConverter::class );
+		$converter = Mockery::mock( ContentConverterInterface::class );
 		$converter->shouldReceive( 'convert' )
 			->with( 'classic content' )
 			->andReturn( '<!-- wp:paragraph --><p>classic content</p><!-- /wp:paragraph -->' );
@@ -103,7 +103,7 @@ class MigrationRunnerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_dry_run_skips_lock_check(): void {
-		$converter = Mockery::mock( ContentConverter::class );
+		$converter = Mockery::mock( ContentConverterInterface::class );
 		$converter->shouldReceive( 'convert' )->andReturn( 'converted' );
 
 		$runner = new MigrationRunner( $converter );
@@ -123,7 +123,7 @@ class MigrationRunnerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_successful_conversion_flow(): void {
-		$converter = Mockery::mock( ContentConverter::class );
+		$converter = Mockery::mock( ContentConverterInterface::class );
 		$converter->shouldReceive( 'convert' )
 			->with( 'original' )
 			->andReturn( 'converted' );
@@ -153,7 +153,7 @@ class MigrationRunnerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_returns_failure_when_update_fails(): void {
-		$converter = Mockery::mock( ContentConverter::class );
+		$converter = Mockery::mock( ContentConverterInterface::class );
 		$converter->shouldReceive( 'convert' )->andReturn( 'converted' );
 
 		$runner   = new MigrationRunner( $converter );
@@ -182,7 +182,7 @@ class MigrationRunnerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_batch_converts_all_posts(): void {
-		$converter = Mockery::mock( ContentConverter::class );
+		$converter = Mockery::mock( ContentConverterInterface::class );
 		$converter->shouldReceive( 'convert' )->andReturn( 'converted' );
 
 		$runner = new MigrationRunner( $converter );
@@ -212,7 +212,7 @@ class MigrationRunnerTest extends TestCase {
 	 * @return void
 	 */
 	public function test_skips_revision_meta_when_no_revision_created(): void {
-		$converter = Mockery::mock( ContentConverter::class );
+		$converter = Mockery::mock( ContentConverterInterface::class );
 		$converter->shouldReceive( 'convert' )->andReturn( 'converted' );
 
 		$runner = new MigrationRunner( $converter );


### PR DESCRIPTION
## Summary

- Extract `ContentConverterInterface` so addon plugins can provide custom conversion pipelines
  without relying on global filter hooks (#33)
- Extract `BlockMarkup` utility class with public `wrap()` and `self_closing()` helpers
  for addon plugins that build blocks outside of a `BlockConverterInterface` (#34)
- `MigrationRunner` accepts the interface; `AbstractBlockConverter` delegates to `BlockMarkup`

Closes #33, closes #34

## Test plan

- [x] All 75 unit tests pass
- [x] PHPStan clean
- [x] PHPCS clean
- [x] CI green