### PR TITLE
fix(bootstrap): use class_exists guard, not vendor/autoload check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-05-25
+
+### Fixed
+
+- Bootstrap in `plugin.php` no longer false-positives the "Please run
+  `composer install`" notice when the plugin runs inside a
+  Composer-managed parent project (Bedrock and similar). The check now
+  loads the local autoloader if present, then verifies `Plugin` is
+  reachable (via either the local or the parent autoloader) before
+  showing the notice. See
+  [#49](https://github.com/apermo/classic-to-gutenberg/issues/49).
+
 ## [0.5.0] - 2026-03-24
 
 ### Added

--- a/plugin.php
+++ b/plugin.php
@@ -21,7 +21,11 @@ namespace Apermo\ClassicToGutenberg;
 \define( 'CLASSIC_TO_GUTENBERG_FILE', __FILE__ );
 \define( 'CLASSIC_TO_GUTENBERG_DIR', plugin_dir_path( __FILE__ ) );
 
-if ( ! \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+if ( \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
+
+if ( ! \class_exists( Plugin::class ) ) {
 	add_action( 'admin_notices', 'Apermo\ClassicToGutenberg\ctg_missing_autoloader_notice' );
 	return;
 }
@@ -43,7 +47,5 @@ function ctg_missing_autoloader_notice(): void {
 		),
 	);
 }
-
-require_once __DIR__ . '/vendor/autoload.php';
 
 Plugin::init();


### PR DESCRIPTION
## Summary

- Replace the `file_exists( vendor/autoload.php )` guard in `plugin.php` with a `class_exists( Plugin::class )` check after an optional local-autoloader load.
- Eliminates the false-positive "Please run `composer install`" admin notice when the plugin runs inside a Composer-managed parent project (Bedrock and similar), where the parent's autoloader already provides `Apermo\ClassicToGutenberg\Plugin`.
- Wording of the notice, the `ctg_missing_autoloader_notice()` callback, and the translation string are unchanged — only the condition that triggers the notice.

Closes #49. Root cause shared with apermo/template-wordpress#45.

## Test plan

- [ ] Standalone install (no parent Composer, no local `vendor/`): notice shows, plugin returns early.
- [ ] Standalone install with `composer install` run: local autoloader loads, `Plugin::init()` runs, no notice.
- [ ] Parent-Composer-managed install (e.g. Bedrock): parent autoloader provides `Plugin`, no local `vendor/` present, no notice, `Plugin::init()` runs.